### PR TITLE
Threads 投稿機能の追加（MVP: テキスト投稿）

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,11 @@
 PPPOST_TWITTER_APPKEY=your_twitter_app_key
 PPPOST_TWITTER_APPSECRET=your_twitter_app_secret
 
+# Threads API設定
+PPPOST_THREADS_CLIENT_ID=your_threads_client_id
+PPPOST_THREADS_CLIENT_SECRET=your_threads_client_secret
+PPPOST_THREADS_REDIRECT_URL=https://your-app-url/
+
 # データ暗号化設定
 PPPOST_DATA_SECRET=your_32_byte_secret_key
 PPPOST_DATA_IV=your_16_byte_iv

--- a/backend/netlify/functions/threads_post.js
+++ b/backend/netlify/functions/threads_post.js
@@ -1,0 +1,78 @@
+const fetch = require('node-fetch')
+
+const handler = async (event) => {
+  // CORS対応
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      },
+      body: '',
+    };
+  }
+
+  try {
+    const { user_id, token, text } = JSON.parse(event.body);
+
+    // 1. メディアコンテナ作成（media_type=TEXT）
+    const createRes = await fetch(`https://graph.threads.net/v1.0/${user_id}/threads`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `media_type=TEXT&text=${encodeURIComponent(text)}&access_token=${encodeURIComponent(token)}`,
+    });
+
+    if (!createRes.ok) {
+      console.error(`threads container creation failed: ${createRes.status}`, await createRes.text());
+      return {
+        statusCode: createRes.status,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ error: 'failed to create threads container' })
+      };
+    }
+
+    const createJson = await createRes.json();
+    const creation_id = createJson.id;
+
+    // 2. 公開
+    const publishRes = await fetch(`https://graph.threads.net/v1.0/${user_id}/threads_publish`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `creation_id=${encodeURIComponent(creation_id)}&access_token=${encodeURIComponent(token)}`,
+    });
+
+    if (!publishRes.ok) {
+      console.error(`threads publish failed: ${publishRes.status}`, await publishRes.text());
+      return {
+        statusCode: publishRes.status,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ error: 'failed to publish threads' })
+      };
+    }
+
+    const response = {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({})
+    };
+    console.info('post threads succeeded', response);
+    return response;
+  } catch (error) {
+    console.log(`handler -> error:`, error);
+    return { statusCode: 500, body: error.toString() }
+  }
+}
+
+module.exports = { handler }

--- a/backend/netlify/functions/threads_token.js
+++ b/backend/netlify/functions/threads_token.js
@@ -1,0 +1,76 @@
+const fetch = require('node-fetch')
+
+const handler = async (event) => {
+  console.log(`start handler - `, event);
+
+  try {
+    const code = event.queryStringParameters.code ?? 'empty';
+
+    const client_id = process.env.PPPOST_THREADS_CLIENT_ID;
+    const client_secret = process.env.PPPOST_THREADS_CLIENT_SECRET;
+    const redirect_uri = process.env.PPPOST_THREADS_REDIRECT_URL;
+
+    // 1. 短命トークンと user_id を取得
+    const shortRes = await fetch(`https://graph.threads.net/oauth/access_token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `client_id=${client_id}&client_secret=${client_secret}&grant_type=authorization_code&code=${code}&redirect_uri=${redirect_uri}`,
+    });
+
+    if (!shortRes.ok) {
+      console.error(`short-lived token request failed: ${shortRes.status}`, await shortRes.text());
+      return {
+        statusCode: shortRes.status,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ error: 'failed to get short-lived token' })
+      }
+    }
+
+    const shortJson = await shortRes.json();
+    const user_id = shortJson.user_id;
+    const shortToken = shortJson.access_token;
+
+    // 2. 長命トークン（60 日）へ交換
+    const longRes = await fetch(`https://graph.threads.net/access_token?grant_type=th_exchange_token&client_secret=${client_secret}&access_token=${shortToken}`);
+
+    if (!longRes.ok) {
+      console.error(`long-lived token request failed: ${longRes.status}`, await longRes.text());
+      return {
+        statusCode: longRes.status,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ error: 'failed to get long-lived token' })
+      }
+    }
+
+    const longJson = await longRes.json();
+
+    const response = {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        user_id,
+        access_token: longJson.access_token,
+        token_type: longJson.token_type,
+        expires_in: longJson.expires_in,
+      })
+    };
+    console.log(`finish handler - `, response);
+
+    return response;
+
+  } catch (error) {
+    console.log(`failed to get token:`, error);
+    return { statusCode: 500, body: error.toString() }
+  }
+}
+
+module.exports = { handler }

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -6,6 +6,10 @@ export type ConfigType = {
       server: string,
       client_id: string,
     }[],
+    threads: {
+      client_id: string,
+      redirect_uri: string,
+    },
   },
 }
 
@@ -26,6 +30,10 @@ export const Config = ((): ConfigType => {
     API_ENDPOINT: import.meta.env.VITE_API_ENDPOINT,
     post_targets: {
       mastodon,
+      threads: {
+        client_id: import.meta.env.VITE_THREADS_CLIENT_ID,
+        redirect_uri: import.meta.env.VITE_THREADS_REDIRECT_URL,
+      },
     }
   };
 })();

--- a/frontend/src/lib/MainContent.svelte
+++ b/frontend/src/lib/MainContent.svelte
@@ -6,7 +6,9 @@ import twitterText from "twitter-text";
 
 import MastodonConnection from "./MastodonConnection.svelte";
 import BlueskyConnection from "./BlueskyConnection.svelte";
-import { loadMessage, loadPostSetting, saveMessage, type SettingType } from "./func";
+import ThreadsConnection from "./ThreadsConnection.svelte";
+import { loadMessage, loadPostSetting, saveMessage, savePostSetting, type SettingType } from "./func";
+import { Config } from "../config";
 import { getApiVersion, loadMyPosts, postSettings, postTo, postToSns, type Post, type PresentedPost, type ImageData } from "./MainContent"; // .ts 拡張子を削除
 import ImagePreview from "./ImagePreview.svelte";
 import dayjs from "dayjs";
@@ -33,6 +35,7 @@ let replyToPost: PresentedPost = {
   postOfType: {
     mastodon: undefined,
     bluesky: undefined,
+    threads: undefined,
   }
 };
 
@@ -131,6 +134,33 @@ onMount(async () => {
     // }
 
     const urlParams = new URLSearchParams(window.location.search);
+
+    // Threads OAuth コールバック処理
+    if (urlParams.get('state') === 'threads_callback' && urlParams.has('code')) {
+      const code = urlParams.get('code') ?? '';
+      const res = await fetch(`${Config.API_ENDPOINT}/threads_token?code=${encodeURIComponent(code)}`);
+      if (res.ok) {
+        const resJson = await res.json();
+        savePostSetting({
+          type: 'threads',
+          title: 'Threads',
+          enabled: true,
+          user_id: resJson.user_id,
+          token_data: {
+            access_token: resJson.access_token,
+            token_type: resJson.token_type,
+            expires_in: resJson.expires_in,
+            obtained_at: Date.now(),
+          },
+        });
+        onChangePostSettings();
+      } else {
+        console.error(`failed to exchange threads token:`, res);
+      }
+
+      // URL から code を除去する
+      history.replaceState(null, '', window.location.pathname);
+    }
 
     const content = urlParams.get('text');
     const url = urlParams.get('url');
@@ -260,6 +290,7 @@ const post = async () => {
         postOfType: {
           mastodon: undefined,
           bluesky: undefined,
+          threads: undefined,
         }
       };
       posted = true;
@@ -278,6 +309,7 @@ const post = async () => {
 const onChangePostSettings = () => {
   postSettings.mastodon = loadPostSetting('mastodon');
   postSettings.bluesky = loadPostSetting('bluesky');
+  postSettings.threads = loadPostSetting('threads');
 
   Object.entries(postTo).forEach(([k, v]) => {
     postTo[k as SettingType] = postSettings?.[k as SettingType]?.enabled ?? false;
@@ -320,6 +352,12 @@ const getTypes = (post: PresentedPost) => {
       <BlueskyConnection on:onChange={onChangePostSettings} />
     </div>
   </div>
+  <div class="form-check mb-0 d-flex flex-row align-items-start gap-1">
+    <input class="mt-1 form-check-input" type="checkbox" bind:checked={postTo.threads} id="threads" disabled={postSettings.threads == null}>
+    <div class="w-100">
+      <ThreadsConnection on:onChange={onChangePostSettings} />
+    </div>
+  </div>
 </div>
 
 <div class="mt-4">
@@ -354,6 +392,9 @@ const getTypes = (post: PresentedPost) => {
       {#if postSettings.bluesky != null && postTo.bluesky}
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -3.268 64 68.414" width="16" height="16"><path fill="currentColor" d="M13.873 3.805C21.21 9.332 29.103 20.537 32 26.55v15.882c0-.338-.13.044-.41.867-1.512 4.456-7.418 21.847-20.923 7.944-7.111-7.32-3.819-14.64 9.125-16.85-7.405 1.264-15.73-.825-18.014-9.015C1.12 23.022 0 8.51 0 6.55 0-3.268 8.579-.182 13.873 3.805zm36.254 0C42.79 9.332 34.897 20.537 32 26.55v15.882c0-.338.13.044.41.867 1.512 4.456 7.418 21.847 20.923 7.944 7.111-7.32 3.819-14.64-9.125-16.85 7.405 1.264 15.73-.825 18.014-9.015C62.88 23.022 64 8.51 64 6.55c0-9.818-8.578-6.732-13.873-2.745z"/></svg>
       {/if}
+      {#if postSettings.threads != null && postTo.threads}
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="16" height="16"><path fill="currentColor" d="M141.537 88.988a66.667 66.667 0 0 0-2.518-1.143c-1.482-27.307-16.403-42.94-41.457-43.1h-.34c-14.986 0-27.449 6.396-35.12 18.036l13.779 9.452c5.73-8.695 14.724-10.548 21.348-10.548h.229c8.249.053 14.474 2.452 18.503 7.129 2.932 3.405 4.893 8.111 5.864 14.05-7.314-1.243-15.224-1.626-23.68-1.14-23.82 1.371-39.134 15.264-38.105 34.568.522 9.792 5.4 18.216 13.735 23.719 7.047 4.652 16.124 6.927 25.557 6.412 12.458-.683 22.231-5.436 29.049-14.127 5.178-6.6 8.453-15.153 9.899-25.93 5.937 3.583 10.337 8.298 12.767 13.966 4.132 9.635 4.373 25.468-8.546 38.376-11.319 11.308-24.925 16.2-45.488 16.351-22.809-.169-40.06-7.484-51.275-21.742C35.236 139.966 29.808 120.682 29.605 96c.203-24.682 5.63-43.966 16.133-57.317C56.954 24.425 74.204 17.11 97.013 16.94c22.975.17 40.526 7.52 52.171 21.847 5.71 7.026 10.015 15.86 12.853 26.162l16.147-4.308c-3.44-12.68-8.853-23.606-16.219-32.668C147.036 9.607 124.999.195 97.07 0h-.113C69.087.194 47.295 9.642 32.32 28.08 18.994 44.485 12.12 67.315 11.89 95.932L11.89 96l.001.067c.23 28.617 7.104 51.448 20.43 67.853C47.295 182.358 69.087 191.806 96.957 192h.113c24.78-.172 42.236-6.652 56.61-21.019 18.806-18.788 18.24-42.343 12.05-56.78-4.441-10.359-12.91-18.769-24.493-24.319l.3.106Z"/></svg>
+      {/if}
       <span>Post</span>
     </div>
     {/if}
@@ -371,6 +412,7 @@ const getTypes = (post: PresentedPost) => {
       postOfType: {
         mastodon: undefined,
         bluesky: undefined,
+        threads: undefined,
       }
     };
     posted = false;

--- a/frontend/src/lib/MainContent.ts
+++ b/frontend/src/lib/MainContent.ts
@@ -1,5 +1,5 @@
 import { Config } from "../config";
-import { type SettingDataMastodon, type SettingDataBluesky, loadPostSetting, type SettingType, loadMessage, savePostSetting } from "./func";
+import { type SettingDataMastodon, type SettingDataBluesky, type SettingDataThreads, loadPostSetting, type SettingType, loadMessage, savePostSetting } from "./func";
 import type { AtpSessionData } from "@atproto/api";
 import dayjs from "dayjs";
 import { uploadImageToSupabase, deleteImagesFromSupabase } from "./supabase-client";
@@ -29,14 +29,17 @@ export interface ImageData {
 export const postSettings: {
   mastodon: SettingDataMastodon | null,
   bluesky: SettingDataBluesky | null,
+  threads: SettingDataThreads | null,
 } = {
   mastodon: loadPostSetting('mastodon'),
   bluesky: loadPostSetting('bluesky'),
+  threads: loadPostSetting('threads'),
 };
 
 export const postTo: { [K in SettingType]: boolean } = {
   mastodon: postSettings?.mastodon?.enabled ?? false,
   bluesky: postSettings?.bluesky?.enabled ?? false,
+  threads: postSettings?.threads?.enabled ?? false,
 };
 
 export async function getApiVersion(): Promise<{ build_at: string, env_ver: string }> {
@@ -139,7 +142,7 @@ export const loadMyPosts = async (): Promise<PresentedPost[]> => {
         grouped[key] = {
           display_posted_at: dayjs(post.posted_at).format('M/DD H:mm'),
           trimmed_text: trimText(post.text),
-          postOfType: { mastodon: undefined, bluesky: undefined }
+          postOfType: { mastodon: undefined, bluesky: undefined, threads: undefined }
         };
       }
       grouped[key].postOfType[type] = post;
@@ -190,6 +193,9 @@ export const postToSns = async (text: string, imageDataURLs: string[], options: 
       break;
     case 'bluesky':
       promises.push(postToBluesky(text, uploadedImageUrls, options?.reply_to_ids?.bluesky).then((r) => { if (!r) errors.push('Bluesky') }));
+      break;
+    case 'threads':
+      promises.push(postToThreads(text).then((r) => { if (!r) errors.push('Threads') }));
       break;
     }
 
@@ -266,6 +272,30 @@ const postToMastodon = async (text: string, imageUrls: string[], reply_to_id: st
     return false;       
   }
 };  
+
+
+const postToThreads = async (text: string): Promise<boolean> => {
+  try {
+    const settings = postSettings.threads!;
+
+    const res = await fetch(`${Config.API_ENDPOINT}/threads_post`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        user_id: settings.user_id,
+        token: settings.token_data.access_token,
+        text,
+      }),
+    });
+
+    return res.ok;
+  } catch (error) {
+    console.error(`postToThreads -> error:`, error);
+    return false;
+  }
+};
 
 
 const loadMyPostsBluesky = async (): Promise<Post[]> => {

--- a/frontend/src/lib/ThreadsConnection.svelte
+++ b/frontend/src/lib/ThreadsConnection.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import { Config } from "../config";
+  import { deletePostSetting, loadPostSetting } from "./func";
+
+  const dispatch = createEventDispatcher<{ onChange: void }>();
+
+  let expandedThreads = false;
+
+  const threadsTarget = Config.post_targets.threads;
+
+  let postSettings = loadPostSetting('threads');
+
+  const onConnectToThreads = () => {
+    const params = new URLSearchParams({
+      client_id: threadsTarget.client_id,
+      redirect_uri: threadsTarget.redirect_uri,
+      response_type: 'code',
+      scope: 'threads_basic,threads_content_publish',
+      state: 'threads_callback',
+    });
+    const url = `https://threads.net/oauth/authorize?${params.toString()}`;
+
+    // 同一タブで authorize ページへ遷移する（別タブだとコールバックを掴めない）
+    window.location.href = url;
+  };
+</script>
+
+<div>
+
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <div class="d-flex flex-row gap-1 align-items-center" style="cursor: pointer;"  on:click={() => {
+    expandedThreads = !expandedThreads;
+  }}>
+    <h5 class="mb-0">Threads</h5>
+    {#if !expandedThreads}
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>
+    </svg>
+    {:else}
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+    </svg>
+    {/if}
+  </div>
+  {#if expandedThreads}
+  <div class="p-1">
+
+    {#if postSettings != null}
+    <div class="d-flex flex-row gap-2 align-items-center">
+      <span>接続済み</span>
+      <button class="btn btn-sm btn-outline-primary" style="width: 60px;" on:click={() => {
+        postSettings = null;
+        deletePostSetting('threads');
+        dispatch('onChange');
+      }}>切断</button>
+    </div>
+    {:else}
+    <div class="d-flex flex-column gap-1">
+      <span>Threads アカウントに接続</span>
+      <div class="d-flex flex-row gap-1">
+        <button class="btn btn-sm btn-primary" style="width: 60px;" on:click={onConnectToThreads}>接続</button>
+      </div>
+    </div>
+    {/if}
+
+
+  </div>
+  {/if}
+</div>

--- a/frontend/src/lib/func.ts
+++ b/frontend/src/lib/func.ts
@@ -22,12 +22,26 @@ export type SettingDataBluesky = {
   }
 };
 
-export type SettingData = SettingDataMastodon | SettingDataBluesky;
+export type SettingDataThreads = {
+  type: 'threads',
+  title: 'Threads',
+  enabled: boolean,
+  user_id: string,
+  token_data: {
+    access_token: string,
+    token_type: string,
+    expires_in: number,
+    obtained_at: number,
+  }
+};
+
+export type SettingData = SettingDataMastodon | SettingDataBluesky | SettingDataThreads;
 
 export type SettingType = SettingData['type'];
 
 export type SettingDataType<T extends SettingType> =
   T extends 'mastodon' ? SettingDataMastodon :
+  T extends 'threads' ? SettingDataThreads :
   SettingDataBluesky;
 
 export function savePostSetting(data: SettingData) {

--- a/openspec/changes/PPP-009-add-threads-posting/proposal.md
+++ b/openspec/changes/PPP-009-add-threads-posting/proposal.md
@@ -15,7 +15,7 @@
 - `MainContent.svelte` に Threads の投稿対象チェックボックスと投稿ボタン横のアイコンを追加する
 - `MainContent.ts` の `postSettings` / `postTo` に `threads` を追加し、`postToThreads()` 関数と `postToSns` の `switch` 分岐を追加する
 - バックエンド `threads_token.js`（短命→長命トークン交換）と `threads_post.js`（2 段階のテキスト投稿）を新規作成する
-- 環境変数を追加する（バックエンド: `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URI`、フロント: `VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URI`）
+- 環境変数を追加する（バックエンド: `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URL`、フロント: `VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URL`）
 
 ## Non-Goals
 

--- a/openspec/changes/PPP-009-add-threads-posting/tasks.md
+++ b/openspec/changes/PPP-009-add-threads-posting/tasks.md
@@ -11,7 +11,7 @@
 ## 2. 設定（config.ts）
 
 - [ ] 2.1 `post_targets` に `threads: { client_id: string, redirect_uri: string }` を追加する
-- [ ] 2.2 `import.meta.env.VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URI` から値を読み込む
+- [ ] 2.2 `import.meta.env.VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URL` から値を読み込む
 - [ ] 2.3 `client_secret` はフロントに置かないことを確認する（バックエンド env のみ）
 
 ## 3. 接続 UI（ThreadsConnection.svelte）
@@ -47,7 +47,7 @@
 - [ ] 6.2 `GET ?code=<code>` を受け、`POST https://graph.threads.net/oauth/access_token`（`grant_type=authorization_code`）で短命トークンと `user_id` を取得する
 - [ ] 6.3 `GET https://graph.threads.net/access_token`（`grant_type=th_exchange_token`）で長命トークンへ交換する
 - [ ] 6.4 `{ user_id, access_token, token_type, expires_in }` を CORS ヘッダ付きで返す
-- [ ] 6.5 env `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URI` を使用する
+- [ ] 6.5 env `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URL` を使用する
 
 ## 7. バックエンド: 投稿（threads_post.js）
 
@@ -59,9 +59,9 @@
 
 ## 8. 環境変数
 
-- [ ] 8.1 `backend/.env.example` に `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URI` を追記する
-- [ ] 8.2 フロントの env に `VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URI` を追記する（フロントには `.env.example` が存在せず `frontend/.env` のみのため、`frontend/.env` に追記する。必要に応じて `frontend/.env.example` を新規作成してもよい）
-- [ ] 8.3 `redirect_uri` がフロント（`VITE_THREADS_REDIRECT_URI`）とバックエンド（`PPPOST_THREADS_REDIRECT_URI`）で同値であることを確認する
+- [ ] 8.1 `backend/.env.example` に `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URL` を追記する
+- [ ] 8.2 フロントの env に `VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URL` を追記する（フロントには `.env.example` が存在せず `frontend/.env` のみのため、`frontend/.env` に追記する。必要に応じて `frontend/.env.example` を新規作成してもよい）
+- [ ] 8.3 `redirect_uri` がフロント（`VITE_THREADS_REDIRECT_URL`）とバックエンド（`PPPOST_THREADS_REDIRECT_URL`）で同値であることを確認する
 
 ## 9. 動作検証
 

--- a/openspec/changes/PPP-009-add-threads-posting/tasks.md
+++ b/openspec/changes/PPP-009-add-threads-posting/tasks.md
@@ -2,70 +2,70 @@
 
 ## 1. 型定義（func.ts）
 
-- [ ] 1.1 `SettingDataThreads` 型を追加する（`type: 'threads'`, `title: 'Threads'`, `enabled`, `user_id`, `token_data: { access_token, token_type, expires_in, obtained_at }`）。既存の `SettingDataMastodon`/`SettingDataBluesky` に倣い `title` リテラルを持たせる
-- [ ] 1.2 `SettingData` ユニオンに `SettingDataThreads` を追加する
-- [ ] 1.3 `SettingType` に `'threads'` を追加する
-- [ ] 1.4 `SettingDataType<T>` の条件型に `T extends 'threads' ? SettingDataThreads :` を追加する
-- [ ] 1.5 `savePostSetting` / `loadPostSetting` は型駆動のため変更不要であることを確認する（`localStorage` キーは自動的に `ppp_setting_threads`）
+- [x] 1.1 `SettingDataThreads` 型を追加する（`type: 'threads'`, `title: 'Threads'`, `enabled`, `user_id`, `token_data: { access_token, token_type, expires_in, obtained_at }`）。既存の `SettingDataMastodon`/`SettingDataBluesky` に倣い `title` リテラルを持たせる
+- [x] 1.2 `SettingData` ユニオンに `SettingDataThreads` を追加する
+- [x] 1.3 `SettingType` に `'threads'` を追加する
+- [x] 1.4 `SettingDataType<T>` の条件型に `T extends 'threads' ? SettingDataThreads :` を追加する
+- [x] 1.5 `savePostSetting` / `loadPostSetting` は型駆動のため変更不要であることを確認する（`localStorage` キーは自動的に `ppp_setting_threads`）
 
 ## 2. 設定（config.ts）
 
-- [ ] 2.1 `post_targets` に `threads: { client_id: string, redirect_uri: string }` を追加する
-- [ ] 2.2 `import.meta.env.VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URL` から値を読み込む
-- [ ] 2.3 `client_secret` はフロントに置かないことを確認する（バックエンド env のみ）
+- [x] 2.1 `post_targets` に `threads: { client_id: string, redirect_uri: string }` を追加する
+- [x] 2.2 `import.meta.env.VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URL` から値を読み込む
+- [x] 2.3 `client_secret` はフロントに置かないことを確認する（バックエンド env のみ）
 
 ## 3. 接続 UI（ThreadsConnection.svelte）
 
-- [ ] 3.1 `frontend/src/lib/ThreadsConnection.svelte` を新規作成する（`MastodonConnection.svelte` の折りたたみ構造を踏襲）
-- [ ] 3.2 接続ボタン押下で `https://threads.net/oauth/authorize`（`client_id`, `redirect_uri`, `response_type=code`, `scope=threads_basic,threads_content_publish`, `state=threads_callback`）へ `window.location.href` で同一タブ遷移する
-- [ ] 3.3 Mastodon の手動コード貼り付け UI は設けない（リダイレクトで自動取得するため）
-- [ ] 3.4 接続済み表示と切断ボタンを設け、切断で `deletePostSetting('threads')` + `dispatch('onChange')` を行う
+- [x] 3.1 `frontend/src/lib/ThreadsConnection.svelte` を新規作成する（`MastodonConnection.svelte` の折りたたみ構造を踏襲）
+- [x] 3.2 接続ボタン押下で `https://threads.net/oauth/authorize`（`client_id`, `redirect_uri`, `response_type=code`, `scope=threads_basic,threads_content_publish`, `state=threads_callback`）へ `window.location.href` で同一タブ遷移する
+- [x] 3.3 Mastodon の手動コード貼り付け UI は設けない（リダイレクトで自動取得するため）
+- [x] 3.4 接続済み表示と切断ボタンを設け、切断で `deletePostSetting('threads')` + `dispatch('onChange')` を行う
 
 ## 4. コールバック・UI 統合（MainContent.svelte）
 
-- [ ] 4.1 `import ThreadsConnection from "./ThreadsConnection.svelte"` を追加する
-- [ ] 4.2 `onMount` で `state === 'threads_callback'` かつ `code` がある場合に `GET ${Config.API_ENDPOINT}/threads_token?code=<code>` を呼ぶ
-- [ ] 4.3 レスポンス（`user_id`, 長命 `access_token`, `token_type`, `expires_in`）を `savePostSetting`（`obtained_at: Date.now()` 付き）で保存し、`onChangePostSettings()` を呼ぶ
-- [ ] 4.4 `history.replaceState` で URL から `code` を除去する
-- [ ] 4.5 Mastodon/Bluesky と並べて Threads の投稿対象チェックボックス（`bind:checked={postTo.threads}`, `disabled={postSettings.threads == null}`）と `<ThreadsConnection on:onChange={onChangePostSettings} />` を追加する
-- [ ] 4.6 投稿ボタン横に Threads アイコンを `{#if postSettings.threads != null && postTo.threads}` で追加する
-- [ ] 4.7 `onChangePostSettings` に `postSettings.threads = loadPostSetting('threads')` を追加する
-- [ ] 4.8 `postOfType` / `replyToPost` の初期化箇所すべてに `threads: undefined` を追加する（`SettingType` 型網羅のため。リプライ UI 自体は追加しない）
+- [x] 4.1 `import ThreadsConnection from "./ThreadsConnection.svelte"` を追加する
+- [x] 4.2 `onMount` で `state === 'threads_callback'` かつ `code` がある場合に `GET ${Config.API_ENDPOINT}/threads_token?code=<code>` を呼ぶ
+- [x] 4.3 レスポンス（`user_id`, 長命 `access_token`, `token_type`, `expires_in`）を `savePostSetting`（`obtained_at: Date.now()` 付き）で保存し、`onChangePostSettings()` を呼ぶ
+- [x] 4.4 `history.replaceState` で URL から `code` を除去する
+- [x] 4.5 Mastodon/Bluesky と並べて Threads の投稿対象チェックボックス（`bind:checked={postTo.threads}`, `disabled={postSettings.threads == null}`）と `<ThreadsConnection on:onChange={onChangePostSettings} />` を追加する
+- [x] 4.6 投稿ボタン横に Threads アイコンを `{#if postSettings.threads != null && postTo.threads}` で追加する
+- [x] 4.7 `onChangePostSettings` に `postSettings.threads = loadPostSetting('threads')` を追加する
+- [x] 4.8 `postOfType` / `replyToPost` の初期化箇所すべてに `threads: undefined` を追加する（`SettingType` 型網羅のため。リプライ UI 自体は追加しない）
 
 ## 5. 投稿処理（MainContent.ts）
 
-- [ ] 5.1 `postSettings` に `threads: loadPostSetting('threads')` を追加する
-- [ ] 5.2 `postTo` に `threads: postSettings?.threads?.enabled ?? false` を追加する
-- [ ] 5.3 `postToThreads(text: string): Promise<boolean>` を追加する（`POST ${Config.API_ENDPOINT}/threads_post` に `{ user_id, token, text }` を送り `res.ok` を返す。画像・reply_to は渡さない）
-- [ ] 5.4 `postToSns` の `switch` に `case 'threads'` を追加し、失敗時 `errors.push('Threads')` とする
-- [ ] 5.5 `postOfType` 初期化に `threads: undefined` を追加する（型網羅）
-- [ ] 5.6 `loadMyPosts` の `switch` には Threads を追加しない（自投稿取得は対象外）
+- [x] 5.1 `postSettings` に `threads: loadPostSetting('threads')` を追加する
+- [x] 5.2 `postTo` に `threads: postSettings?.threads?.enabled ?? false` を追加する
+- [x] 5.3 `postToThreads(text: string): Promise<boolean>` を追加する（`POST ${Config.API_ENDPOINT}/threads_post` に `{ user_id, token, text }` を送り `res.ok` を返す。画像・reply_to は渡さない）
+- [x] 5.4 `postToSns` の `switch` に `case 'threads'` を追加し、失敗時 `errors.push('Threads')` とする
+- [x] 5.5 `postOfType` 初期化に `threads: undefined` を追加する（型網羅）
+- [x] 5.6 `loadMyPosts` の `switch` には Threads を追加しない（自投稿取得は対象外）
 
 ## 6. バックエンド: トークン交換（threads_token.js）
 
-- [ ] 6.1 `backend/netlify/functions/threads_token.js` を新規作成する（`mastodon_token.js` 同型、CORS 対応）
-- [ ] 6.2 `GET ?code=<code>` を受け、`POST https://graph.threads.net/oauth/access_token`（`grant_type=authorization_code`）で短命トークンと `user_id` を取得する
-- [ ] 6.3 `GET https://graph.threads.net/access_token`（`grant_type=th_exchange_token`）で長命トークンへ交換する
-- [ ] 6.4 `{ user_id, access_token, token_type, expires_in }` を CORS ヘッダ付きで返す
-- [ ] 6.5 env `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URL` を使用する
+- [x] 6.1 `backend/netlify/functions/threads_token.js` を新規作成する（`mastodon_token.js` 同型、CORS 対応）
+- [x] 6.2 `GET ?code=<code>` を受け、`POST https://graph.threads.net/oauth/access_token`（`grant_type=authorization_code`）で短命トークンと `user_id` を取得する
+- [x] 6.3 `GET https://graph.threads.net/access_token`（`grant_type=th_exchange_token`）で長命トークンへ交換する
+- [x] 6.4 `{ user_id, access_token, token_type, expires_in }` を CORS ヘッダ付きで返す
+- [x] 6.5 env `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URL` を使用する
 
 ## 7. バックエンド: 投稿（threads_post.js）
 
-- [ ] 7.1 `backend/netlify/functions/threads_post.js` を新規作成する（OPTIONS プリフライト対応、CORS 対応）
-- [ ] 7.2 body `{ user_id, token, text }` を受ける
-- [ ] 7.3 `POST https://graph.threads.net/v1.0/${user_id}/threads`（`media_type=TEXT`, `text`, `access_token`）でコンテナを作成し `creation_id` を得る
-- [ ] 7.4 `POST https://graph.threads.net/v1.0/${user_id}/threads_publish`（`creation_id`, `access_token`）で公開する
-- [ ] 7.5 いずれかが失敗した場合はエラーステータスを返す（フロントの `errors` 経路で通知）
+- [x] 7.1 `backend/netlify/functions/threads_post.js` を新規作成する（OPTIONS プリフライト対応、CORS 対応）
+- [x] 7.2 body `{ user_id, token, text }` を受ける
+- [x] 7.3 `POST https://graph.threads.net/v1.0/${user_id}/threads`（`media_type=TEXT`, `text`, `access_token`）でコンテナを作成し `creation_id` を得る
+- [x] 7.4 `POST https://graph.threads.net/v1.0/${user_id}/threads_publish`（`creation_id`, `access_token`）で公開する
+- [x] 7.5 いずれかが失敗した場合はエラーステータスを返す（フロントの `errors` 経路で通知）
 
 ## 8. 環境変数
 
-- [ ] 8.1 `backend/.env.example` に `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URL` を追記する
-- [ ] 8.2 フロントの env に `VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URL` を追記する（フロントには `.env.example` が存在せず `frontend/.env` のみのため、`frontend/.env` に追記する。必要に応じて `frontend/.env.example` を新規作成してもよい）
-- [ ] 8.3 `redirect_uri` がフロント（`VITE_THREADS_REDIRECT_URL`）とバックエンド（`PPPOST_THREADS_REDIRECT_URL`）で同値であることを確認する
+- [x] 8.1 `backend/.env.example` に `PPPOST_THREADS_CLIENT_ID` / `PPPOST_THREADS_CLIENT_SECRET` / `PPPOST_THREADS_REDIRECT_URL` を追記する
+- [x] 8.2 フロントの env に `VITE_THREADS_CLIENT_ID` / `VITE_THREADS_REDIRECT_URL` を追記する（フロントには `.env.example` が存在せず `frontend/.env` のみのため、`frontend/.env` に追記する。必要に応じて `frontend/.env.example` を新規作成してもよい）
+- [x] 8.3 `redirect_uri` がフロント（`VITE_THREADS_REDIRECT_URL`）とバックエンド（`PPPOST_THREADS_REDIRECT_URL`）で同値であることを確認する
 
 ## 9. 動作検証
 
-- [ ] 9.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
+- [x] 9.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
 - [ ] 9.2 接続ボタン → Meta 認可 → リダイレクトで長命トークンが保存され「接続済み」表示になることを確認する
 - [ ] 9.3 Threads チェックボックス ON でテキスト投稿が成功することを確認する
 - [ ] 9.4 切断後にチェックボックスが無効化されることを確認する


### PR DESCRIPTION
## Summary
- PPP-009: Threads Graph API + Meta OAuth 2.0 を用いたテキスト投稿機能を実装
- `ThreadsConnection.svelte` 新規作成（Meta OAuth 認可ページへ同一タブ遷移）
- `threads_token.js`（短命→長命トークン交換）・`threads_post.js`（2 段階テキスト投稿）新規作成
- `func.ts`, `config.ts`, `MainContent.svelte`, `MainContent.ts` に Threads 対応を追加

## Test plan
- [ ] 接続ボタン → Meta 認可 → リダイレクトで長命トークンが保存され「接続済み」表示になる
- [ ] Threads チェックボックス ON でテキスト投稿が成功する
- [ ] 切断後にチェックボックスが無効化される
- [ ] Mastodon・Bluesky への投稿が従来通り動作する

🤖 Generated with [Claude Code](https://claude.ai/code)