### PR TITLE
Threads 画像投稿対応

### DIFF
--- a/backend/netlify/functions/threads_post.js
+++ b/backend/netlify/functions/threads_post.js
@@ -1,5 +1,57 @@
 const fetch = require('node-fetch')
 
+const THREADS_API_BASE = 'https://graph.threads.net/v1.0';
+const MAX_IMAGES = 10;
+
+const errorResponse = (statusCode, error) => ({
+  statusCode,
+  headers: {
+    'Access-Control-Allow-Origin': '*',
+  },
+  body: JSON.stringify({ error }),
+});
+
+// メディアコンテナを作成し creation_id を返す。失敗時は null を返す
+const createContainer = async (params) => {
+  const body = Object.entries(params)
+    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+    .join('&');
+
+  const res = await fetch(`${THREADS_API_BASE}/me/threads`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    console.error(`threads container creation failed: ${res.status}`, await res.text());
+    return null;
+  }
+
+  const json = await res.json();
+  return json.id;
+};
+
+// creation_id を公開する。成功時 true、失敗時 false
+const publishContainer = async (creation_id, token) => {
+  const res = await fetch(`${THREADS_API_BASE}/me/threads_publish`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: `creation_id=${encodeURIComponent(creation_id)}&access_token=${encodeURIComponent(token)}`,
+  });
+
+  if (!res.ok) {
+    console.error(`threads publish failed: ${res.status}`, await res.text());
+    return false;
+  }
+
+  return true;
+};
+
 const handler = async (event) => {
   // CORS対応
   if (event.httpMethod === 'OPTIONS') {
@@ -15,49 +67,72 @@ const handler = async (event) => {
   }
 
   try {
-    const { user_id, token, text } = JSON.parse(event.body);
+    const { user_id, token, text, images } = JSON.parse(event.body);
+    const imageUrls = Array.isArray(images) ? images : [];
 
-    // 1. メディアコンテナ作成（media_type=TEXT）
-    const createRes = await fetch(`https://graph.threads.net/v1.0/me/threads`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: `media_type=TEXT&text=${encodeURIComponent(text)}&access_token=${encodeURIComponent(token)}`,
-    });
-
-    if (!createRes.ok) {
-      console.error(`threads container creation failed: ${createRes.status}`, await createRes.text());
-      return {
-        statusCode: createRes.status,
-        headers: {
-          'Access-Control-Allow-Origin': '*',
-        },
-        body: JSON.stringify({ error: 'failed to create threads container' })
-      };
+    // 上限超過: Threads API を呼ばずにエラーを返す
+    if (imageUrls.length > MAX_IMAGES) {
+      console.error(`threads image count exceeds maximum: ${imageUrls.length}`);
+      return errorResponse(400, 'image count exceeds maximum (10)');
     }
 
-    const createJson = await createRes.json();
-    const creation_id = createJson.id;
+    let creation_id;
 
-    // 2. 公開
-    const publishRes = await fetch(`https://graph.threads.net/v1.0/me/threads_publish`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: `creation_id=${encodeURIComponent(creation_id)}&access_token=${encodeURIComponent(token)}`,
-    });
+    if (imageUrls.length === 0) {
+      // テキストのみ投稿（media_type=TEXT）
+      creation_id = await createContainer({
+        media_type: 'TEXT',
+        text,
+        access_token: token,
+      });
+      if (creation_id == null) {
+        return errorResponse(500, 'failed to create threads container');
+      }
+    } else if (imageUrls.length === 1) {
+      // 単画像投稿（media_type=IMAGE）
+      creation_id = await createContainer({
+        media_type: 'IMAGE',
+        image_url: imageUrls[0],
+        text,
+        access_token: token,
+      });
+      if (creation_id == null) {
+        return errorResponse(500, 'failed to create threads container');
+      }
+    } else {
+      // カルーセル投稿（media_type=CAROUSEL）
+      // 子コンテナを並列作成
+      const childIds = await Promise.all(
+        imageUrls.map((image_url) =>
+          createContainer({
+            media_type: 'IMAGE',
+            image_url,
+            access_token: token,
+          })
+        )
+      );
 
-    if (!publishRes.ok) {
-      console.error(`threads publish failed: ${publishRes.status}`, await publishRes.text());
-      return {
-        statusCode: publishRes.status,
-        headers: {
-          'Access-Control-Allow-Origin': '*',
-        },
-        body: JSON.stringify({ error: 'failed to publish threads' })
-      };
+      // 子コンテナのいずれか 1 つでも失敗した場合は投稿全体を失敗とする
+      if (childIds.some((id) => id == null)) {
+        return errorResponse(500, 'failed to create threads child container');
+      }
+
+      // 親コンテナを作成
+      creation_id = await createContainer({
+        media_type: 'CAROUSEL',
+        children: childIds.join(','),
+        text,
+        access_token: token,
+      });
+      if (creation_id == null) {
+        return errorResponse(500, 'failed to create threads carousel container');
+      }
+    }
+
+    // 公開
+    const published = await publishContainer(creation_id, token);
+    if (!published) {
+      return errorResponse(500, 'failed to publish threads');
     }
 
     const response = {

--- a/frontend/src/lib/MainContent.ts
+++ b/frontend/src/lib/MainContent.ts
@@ -195,7 +195,7 @@ export const postToSns = async (text: string, imageDataURLs: string[], options: 
       promises.push(postToBluesky(text, uploadedImageUrls, options?.reply_to_ids?.bluesky).then((r) => { if (!r) errors.push('Bluesky') }));
       break;
     case 'threads':
-      promises.push(postToThreads(text).then((r) => { if (!r) errors.push('Threads') }));
+      promises.push(postToThreads(text, uploadedImageUrls).then((r) => { if (!r) errors.push('Threads') }));
       break;
     }
 
@@ -274,7 +274,7 @@ const postToMastodon = async (text: string, imageUrls: string[], reply_to_id: st
 };  
 
 
-const postToThreads = async (text: string): Promise<boolean> => {
+const postToThreads = async (text: string, imageUrls: string[]): Promise<boolean> => {
   try {
     const settings = postSettings.threads!;
 
@@ -287,6 +287,7 @@ const postToThreads = async (text: string): Promise<boolean> => {
         user_id: settings.user_id,
         token: settings.token_data.access_token,
         text,
+        images: imageUrls,
       }),
     });
 

--- a/openspec/changes/PPP-010-add-threads-image-posting/proposal.md
+++ b/openspec/changes/PPP-010-add-threads-image-posting/proposal.md
@@ -1,0 +1,32 @@
+# Threads 画像投稿対応
+
+## Why
+
+PPP-009 で実装した Threads 投稿機能はテキストのみ対応で、画像は Non-Goal としていた。Mastodon・Bluesky では画像付き投稿が可能なため、Threads でも同様に対応し、マルチ SNS 投稿体験を統一する。
+
+Threads API は画像を「公開 URL」として受け取る仕様のため、既存の Supabase 一時保存フローを再利用できる。
+
+本変更は PPP-009（Threads テキスト投稿）の完了を前提とする。PPP-009 のテキスト投稿要件には「MVP では画像を Threads へ送信してはならない (SHALL NOT)」という制約があるため、本変更ではこの制約を解除する。
+
+## What Changes
+
+- PPP-009 の `### Requirement: Threads へのテキスト投稿` を MODIFIED で取り込み、「画像を送信してはならない (SHALL NOT)」制約を解除する
+- `### Requirement: Threads への画像投稿`（ADDED）を追加し、単画像・カルーセル投稿、11 枚以上の上限超過時の挙動を定義する
+- `### Requirement: Threads 画像投稿失敗時のエラー通知`（ADDED）を追加し、多段フローの失敗時にエラー一覧へ `Threads` を含める要件を定義する
+- `backend/netlify/functions/threads_post.js` に `images`（Supabase 公開 URL 配列）受け取りを追加し、単画像（`media_type=IMAGE`）とカルーセル（`media_type=CAROUSEL`）の 2 段階投稿フローを実装する
+- `frontend/src/lib/MainContent.ts` の `postToThreads()` に `imageUrls: string[]` 引数を追加し、`postToSns` の `case 'threads'` から渡す
+
+## Non-Goals
+
+- 動画投稿（`media_type=VIDEO`）
+- Threads 専用の画像リサイズ（Supabase アップロード前に Mastodon・Bluesky 用リサイズは既存処理で行われるため、Threads でもその URL を流用する）
+
+## Impact
+
+- **Dependencies**: PPP-009（Threads テキスト投稿）の完了を前提とする。本変更は PPP-009 の `postToThreads` / `threads_post.js` を拡張する。
+- **Affected specs**: threads-posting（MODIFIED: テキスト投稿要件 / ADDED: 画像投稿・画像投稿失敗通知）
+- **Affected code**:
+  - 変更: `backend/netlify/functions/threads_post.js`, `frontend/src/lib/MainContent.ts`
+- **Breaking changes**: なし（テキストのみ投稿は従来通り動作する）
+
+> 注: image-upload spec（Mastodon リサイズ仕様）は変更しない。Threads は Supabase 公開 URL を流用するだけでリサイズ処理を持たないため、image-upload への影響はない。

--- a/openspec/changes/PPP-010-add-threads-image-posting/references/reviews/spec/spec-review-202606041800.md
+++ b/openspec/changes/PPP-010-add-threads-image-posting/references/reviews/spec/spec-review-202606041800.md
@@ -1,0 +1,106 @@
+# Review: PPP-010-add-threads-image-posting
+
+- **Date**: 2026/06/04 18:00 JST
+- **Reviewer**: openspec-reviewer
+- **Model**: claude-opus-4-8[1m]
+- **Iteration**: 1 / 10
+- **Result**: FAIL
+
+## Summary
+
+Threads 画像投稿対応の proposal。`openspec validate --strict` は PASS するが、spec デルタの操作種別（MODIFIED）が前提とする既存 Requirement が存在しない（実質 ADDED であるべき）こと、proposal の Impact に記載した image-upload spec のデルタが欠落していること、最大 10 枚という上限値の根拠/エラー処理が spec に未定義であることなど、Critical/Major の指摘がある。
+
+## Issues
+
+### Issue 1: MODIFIED の対象 Requirement が存在しない（実質 ADDED）
+- **Severity**: Critical
+- **Location**: `specs/threads-posting/spec.md`
+- **Line**: 7-9
+- **Description**: spec デルタが `## MODIFIED Requirements` 配下に `### Requirement: Threads image posting` を定義しているが、この Requirement 名は基準となる PPP-009 の spec（`### Requirement: Threads アカウント接続` / `### Requirement: Threads へのテキスト投稿` / `### Requirement: Threads 本文の文字数上限`）に存在しない。MODIFIED は「既存 Requirement を全文置換する」操作であり、対象が存在しない以上、これは新規追加であって MODIFIED ではない。`openspec validate` が通るのは threads-posting がまだ正式 spec（`openspec/specs/threads-posting/`）に昇格しておらず、PPP-009 と PPP-010 の両方が変更案として存在するため検証対象外になっているからにすぎない。PPP-009 archive 後にこのデルタを archive すると、MODIFIED の意味論上「Threads image posting」という存在しない要件の置換となり、テキスト投稿要件（Post text to Threads）が画像要件で上書き・消失するリスクがある。
+- **Suggestion**: 画像投稿は PPP-009 のテキスト投稿要件とは独立した新規要件であるため `## ADDED Requirements` に変更する。もしテキスト投稿要件の振る舞い（画像を送信してはならない SHALL NOT 等）を変更する意図があるなら、`### Requirement: Threads へのテキスト投稿` を MODIFIED として全文（header + 全 Scenario）コピーし、画像対応を反映した内容に書き換える。後者の場合、PPP-009 の「MVP では画像を Threads へ送信してはならない (SHALL NOT)」との矛盾解消も必要。
+
+### Issue 2: PPP-009 のテキスト投稿要件との矛盾が未解消
+- **Severity**: Major
+- **Location**: `specs/threads-posting/spec.md`, `proposal.md`
+- **Description**: PPP-009 の `### Requirement: Threads へのテキスト投稿` には「MVP では画像およびリプライ先を Threads へ送信してはならない (SHALL NOT)」と明記されている。PPP-010 はこの制約を解除するものだが、spec デルタ・proposal のどちらにもこの SHALL NOT を撤回・修正する記述がない。結果として archive 後の正式 spec 上、「画像を送信してはならない」と「画像付き投稿を行わなければならない」が併存し、要件矛盾となる。
+- **Suggestion**: `### Requirement: Threads へのテキスト投稿` を MODIFIED で取り込み、「画像を送信してはならない」部分を削除/修正する。または当該 SHALL NOT を撤回する旨を明示する。
+
+### Issue 3: image-upload spec のデルタが欠落
+- **Severity**: Major
+- **Location**: `proposal.md`
+- **Line**: 21
+- **Description**: proposal の Impact に「**Affected specs**: threads-posting（MODIFIED）、image-upload（MODIFIED: Threads 対応追記）」とあるが、`specs/image-upload/` 配下の spec デルタファイルが proposal 内に存在しない（デルタは threads-posting のみ）。Impact の記述と実体が不一致。なお既存 `openspec/specs/image-upload/spec.md` は Mastodon のリサイズ仕様のみで Bluesky すら言及がなく、Threads は Supabase 公開 URL を流用するだけでリサイズ処理を持たない（Non-Goals 記載）ため、そもそも image-upload を MODIFIED する必要があるか自体が疑問。
+- **Suggestion**: image-upload を変更しないなら Impact から image-upload の記述を削除する。変更するなら `specs/image-upload/spec.md` デルタを追加する。
+
+### Issue 4: 最大 10 枚の上限超過時の挙動が未定義
+- **Severity**: Major
+- **Location**: `specs/threads-posting/spec.md`
+- **Line**: 13
+- **Description**: 「最大 10 枚まで対応しなければならない (SHALL)」とあるが、11 枚以上添付された場合の挙動（エラーにするのか、先頭 10 枚に切り詰めるのか、フロントで送信前に弾くのか）が Requirement・Scenario・tasks のいずれにも定義されていない。テスト不可能なエッジケースが残る。また 10 という上限値の根拠（Threads API のカルーセル上限）への参照もない。
+- **Suggestion**: 上限超過時の挙動を Requirement に明記し、対応する Scenario（例: 11 枚添付時に Threads 投稿を失敗として扱いエラー一覧に `Threads` を含める）を追加する。tasks にも上限チェック処理を追加する。
+
+### Issue 5: エラー時の挙動が PPP-009 のエラー通知要件と接続されていない
+- **Severity**: Major
+- **Location**: `specs/threads-posting/spec.md`, `tasks.md`
+- **Line**: spec 全体 / tasks 1.5
+- **Description**: 画像投稿は「子コンテナ並列作成 → 親コンテナ作成 → 公開」の多段フローで、単画像より失敗点が多い。PPP-009 の投稿要件には「失敗を無言で握りつぶしてはならず (SHALL NOT)、エラー一覧に `Threads` を含めて通知 (SHALL)」という明確な要件があるが、PPP-010 の image posting Requirement にはエラー時の通知要件・Scenario が一切ない（tasks 1.5 で「エラーステータスを返す」のみ）。子コンテナ一部失敗時の挙動（残りを中断するか）も未定義。
+- **Suggestion**: 画像投稿失敗時（コンテナ作成・公開のいずれかの失敗、子コンテナ一部失敗を含む）にエラー一覧へ `Threads` を含める要件と失敗 Scenario を追加する。
+
+### Issue 6: コンテナの非同期処理ステータス確認が未考慮
+- **Severity**: Minor
+- **Location**: `specs/threads-posting/spec.md`, `tasks.md`
+- **Description**: Threads API の画像/カルーセルコンテナは作成直後に publish 可能とは限らず、`status` が `FINISHED` になるまでポーリングが推奨される（IN_PROGRESS の状態でも作成 ID は返る）。テキスト投稿（TEXT）では即時 publish できたが、画像/カルーセルでは publish が早すぎると失敗しうる。spec・tasks にこの考慮がない。
+- **Suggestion**: コンテナ作成後に publish 前のステータス確認（または短時間待機）が必要かを設計判断として明記する。最低限 Non-Goals または Open Question として記載する。
+
+### Issue 7: proposal/tasks のフィールド名と実コードの不一致
+- **Severity**: Minor
+- **Location**: `proposal.md` 11行目 / `tasks.md` 1.3, 1.4 / `tasks.md` 2.3
+- **Description**: 既存実装 `frontend/src/lib/MainContent.ts` の `postToThreads` は body に `{ user_id, token, text }`（キー名 `token`）を送り、`backend/.../threads_post.js` も `token` を受け取って内部で `access_token` パラメータに詰めている。tasks 1.3/1.4 は API パラメータとしての `access_token` を記述しており（これは Threads API 仕様としては正しい）混同はないが、tasks 2.3 で追加する body フィールド名が `images` であることは明記されている一方、既存 body の `token`/`user_id` 命名との一貫性は spec/tasks で読み取りにくい。実装時の混乱を避けるため body フィールド名（フロント→バックエンド）と Threads API パラメータ名を区別して記述するのが望ましい。
+- **Suggestion**: tasks 1.1 で受け取る body フィールドを `images`（既存 `user_id`/`token`/`text` と同階層）と明示し、Threads API へ渡すパラメータ（`image_url`/`media_type`/`access_token`）と区別する。
+
+### Issue 8: 依存関係（PPP-009 未 archive）への言及がない
+- **Severity**: Minor
+- **Location**: `proposal.md`
+- **Description**: PPP-010 は PPP-009 のテキスト投稿フロー（`postToThreads`, `threads_post.js`）に直接依存して拡張するが、PPP-009 は現在 40/46 tasks で未完了・未 archive（`openspec/specs/threads-posting/` が未生成）。PPP-010 の前提（PPP-009 完了）が proposal に明記されていない。
+- **Suggestion**: proposal に PPP-009 完了を前提とする旨（依存関係）を記載する。
+
+## Checklist
+
+### A. フォーマット検証
+- [x] Requirement に SHALL/MUST が含まれている
+- [x] 各 Requirement に Scenario がある
+- [ ] MODIFIED 要件に元の内容が完全に記載（→ Issue 1: そもそも MODIFIED 対象が存在しない）
+- [x] proposal.md に Why/What Changes/Impact がある
+- [x] openspec validate --strict がパス
+
+### B0. Plan ↔ Proposal/Spec 整合性（plan.md がある場合）
+- [N/A] plan.md が存在しないためスキップ
+
+### B. 内容面レビュー
+- [ ] 要件間に矛盾がない（→ Issue 2: PPP-009 の SHALL NOT と矛盾）
+- [x] 曖昧な表現がない
+- [ ] シナリオがテスト可能（→ Issue 4: 11 枚以上の挙動が未定義）
+- [ ] エッジケース・エラーケースが網羅されている（→ Issue 4, 5, 6）
+- [ ] 影響範囲が妥当（→ Issue 3: image-upload デルタ欠落）
+- [ ] ビジネスロジックが整合（→ Issue 2, 5）
+- [x] プロジェクトドキュメントと整合（命名規則・技術スタックは整合）
+- [x] Spec ↔ Proposal 整合: proposal の意図が spec で網羅されている
+- [ ] Spec ↔ Proposal 整合: 暗黙の前提が spec で明文化されている（→ Issue 6 コンテナ status）
+- [ ] Spec ↔ Proposal 整合: 処理経路が完結している（→ Issue 5 エラー経路）
+
+### C. ドメイン境界変更の影響分析
+- [x] API フィールド追加の影響を確認（要対応: body に `images` 追加。フロント `postToThreads` 引数とバックエンド受け取りの双方に反映必要。Issue 7 参照）
+- [x] DB 列値追加の影響を確認（該当なし）
+- [x] 定数追加の影響を確認（該当なし）
+- [x] テーブルへの新規レコードの影響を確認（該当なし。Supabase 一時保存は既存フロー流用）
+
+### D. タスク計画レビュー
+- [ ] 各 Requirement に対応するタスクがある（上限超過・エラー通知の Requirement 不足に伴いタスクも欠落。Issue 4, 5）
+- [ ] 各 Scenario を検証するタスクがある（テキストのみ/単画像/複数画像の検証はあるが、失敗系・上限超過の検証タスクなし）
+- [x] タスクに対象ファイルが明記されている
+- [x] タスクの順序が依存関係を考慮している
+- [x] 検証/テストタスクが含まれている（3.1〜3.5。ただしエラー系・上限系が未カバー）
+
+## Conclusion
+
+FAIL。Critical 1 件（Issue 1: MODIFIED 操作種別の誤り）、Major 4 件（Issue 2/3/4/5）を含む。特に Issue 1・2 は archive 時に既存テキスト投稿要件を破壊・矛盾させる重大問題であり、操作種別を ADDED に変更（またはテキスト投稿要件を正しく MODIFIED で取り込み）したうえで、上限超過・エラー通知の要件/Scenario/タスクを補完する必要がある。上記指摘を解消してから再レビューを推奨する。

--- a/openspec/changes/PPP-010-add-threads-image-posting/references/reviews/spec/spec-review-202606041804.md
+++ b/openspec/changes/PPP-010-add-threads-image-posting/references/reviews/spec/spec-review-202606041804.md
@@ -1,0 +1,71 @@
+# Review: PPP-010-add-threads-image-posting
+
+- **Date**: 2026/06/04 18:04 JST
+- **Reviewer**: openspec-reviewer
+- **Model**: claude-opus-4-8[1m]
+- **Iteration**: 2 / 10
+- **Result**: PASS
+
+## Summary
+
+前回（Iteration 1）の Critical 1 件・Major 4 件・Minor 3 件はすべて解消された。MODIFIED 操作種別の誤りは「テキスト投稿要件の正しい全文 MODIFIED 取り込み + 画像投稿の ADDED」へ修正され、PPP-009 の SHALL NOT 矛盾、image-upload デルタ欠落、上限超過挙動、エラー通知経路、コンテナ status 考慮もすべて反映済み。`openspec validate --strict` は PASS。実装へ進めることを推奨する。
+
+## Issues
+
+指摘事項なし（Minor 含めて新規・残存の指摘なし）。
+
+## Previous Issues Resolution
+
+前回（Iteration 1）の指摘事項と修正状況:
+
+| # | Issue | Severity | Status |
+|---|-------|----------|--------|
+| 1 | MODIFIED の対象 Requirement が存在しない（実質 ADDED） | Critical | **修正済み** - `### Requirement: Threads へのテキスト投稿` を PPP-009 の正式名称で MODIFIED として全文取り込み、画像投稿は `## ADDED Requirements` 配下に `### Requirement: Threads への画像投稿` として分離。操作種別の意味論が正しくなった |
+| 2 | PPP-009 のテキスト投稿要件との矛盾が未解消 | Major | **修正済み** - MODIFIED 版で「画像を送信してはならない (SHALL NOT)」を削除し「画像を添付して投稿する場合の振る舞いは画像投稿要件に従う」へ書き換え。リプライ先の SHALL NOT は維持。proposal Why にも制約解除を明記 |
+| 3 | image-upload spec のデルタが欠落 | Major | **修正済み** - Impact から image-upload を削除し「Threads は Supabase 公開 URL を流用するだけでリサイズ処理を持たないため image-upload への影響はない」と注記。Affected specs を threads-posting のみに修正 |
+| 4 | 最大 10 枚の上限超過時の挙動が未定義 | Major | **修正済み** - 画像投稿要件に「11 枚以上は投稿を試行してはならず (SHALL NOT)、失敗として扱いエラー一覧に Threads を含める (SHALL)」を明記。10 枚上限は「Threads API のカルーセル上限に合わせ」と根拠を付記。Scenario「上限を超える枚数の添付」と tasks 1.3 / 3.5 を追加 |
+| 5 | エラー時の挙動が PPP-009 のエラー通知要件と接続されていない | Major | **修正済み** - `### Requirement: Threads 画像投稿失敗時のエラー通知`（ADDED）を新設。多段フロー（子/親コンテナ作成・公開）失敗時にエラー一覧へ Threads を含める要件、子コンテナ一部失敗時の投稿全体失敗を明記。Scenario 2 件（子コンテナ作成失敗・公開失敗）と tasks 1.6 / 3.6 を追加 |
+| 6 | コンテナの非同期処理ステータス確認が未考慮 | Minor | **修正済み** - spec に `## Open Questions` を追加し、status=FINISHED ポーリング推奨の事情と「MVP では作成直後 publish、失敗時はエラー通知要件で処理。安定性に問題が出たら後続変更でステータス確認導入を検討」と設計判断を明記 |
+| 7 | proposal/tasks のフィールド名と実コードの不一致 | Minor | **修正済み** - tasks 1.1 / 2.3 で body フィールド `images`（`user_id` / `token` / `text` と同階層）と Threads API パラメータ（`image_url` / `media_type` / `access_token`）を明示的に区別して記述 |
+| 8 | 依存関係（PPP-009 未 archive）への言及がない | Minor | **修正済み** - proposal Why と Impact の Dependencies に「PPP-009（Threads テキスト投稿）の完了を前提とする」を明記 |
+
+## Checklist
+
+### A. フォーマット検証
+- [x] Requirement に SHALL/MUST が含まれている
+- [x] 各 Requirement に Scenario がある
+- [x] MODIFIED 要件に元の内容が完全に記載（PPP-009 の元文を全文取り込み、画像 SHALL NOT 削除以外は保持）
+- [x] proposal.md に Why/What Changes/Impact がある
+- [x] openspec validate --strict がパス
+
+### B0. Plan ↔ Proposal/Spec 整合性（plan.md がある場合）
+- [N/A] plan.md が存在しないためスキップ
+
+### B. 内容面レビュー
+- [x] 要件間に矛盾がない（PPP-009 の SHALL NOT 矛盾は解消）
+- [x] 曖昧な表現がない
+- [x] シナリオがテスト可能（上限超過 11 枚・子コンテナ失敗・公開失敗が具体値で定義）
+- [x] エッジケース・エラーケースが網羅されている（上限超過・多段失敗・テキストのみ・単画像・複数画像）
+- [x] 影響範囲が妥当（image-upload を Impact から除外、threads-posting のみ）
+- [x] ビジネスロジックが整合
+- [x] プロジェクトドキュメントと整合（命名規則・技術スタック整合）
+- [x] Spec ↔ Proposal 整合: proposal の意図が spec で網羅されている
+- [x] Spec ↔ Proposal 整合: 暗黙の前提が spec で明文化されている（コンテナ status を Open Questions で明示）
+- [x] Spec ↔ Proposal 整合: 処理経路が完結している（エラー通知経路を要件化）
+
+### C. ドメイン境界変更の影響分析
+- [x] API フィールド追加の影響を確認（要対応済: body `images` をフロント `postToThreads`/`postToSns` とバックエンド受け取りの双方に反映。tasks 1.1 / 2.1 / 2.2 / 2.3 でカバー）
+- [x] DB 列値追加の影響を確認（該当なし）
+- [x] 定数追加の影響を確認（該当なし）
+- [x] テーブルへの新規レコードの影響を確認（該当なし。Supabase 一時保存は既存フロー流用）
+
+### D. タスク計画レビュー
+- [x] 各 Requirement に対応するタスクがある（画像投稿→1.4/1.5、上限超過→1.3、エラー通知→1.6、フロント→2.x）
+- [x] 各 Scenario を検証するタスクがある（単画像 3.2 / 複数 3.3 / テキストのみ 3.4 / 上限超過 3.5 / 失敗系 3.6）
+- [x] タスクに対象ファイルが明記されている
+- [x] タスクの順序が依存関係を考慮している（バックエンド→フロント→検証）
+- [x] 検証/テストタスクが含まれている（3.1〜3.7、エラー系・上限系もカバー）
+
+## Conclusion
+
+PASS。前回の Critical 1 件・Major 4 件・Minor 3 件はすべて解消され、新規の指摘もない。この proposal は OpenSpec の品質基準を満たしており、実装に進めることを推奨します。

--- a/openspec/changes/PPP-010-add-threads-image-posting/specs/threads-posting/spec.md
+++ b/openspec/changes/PPP-010-add-threads-image-posting/specs/threads-posting/spec.md
@@ -1,0 +1,87 @@
+# Threads Posting Specification
+
+## Overview
+
+Threads Graph API を用いたテキスト・画像投稿機能の仕様。本デルタは PPP-009（テキスト投稿）の `### Requirement: Threads へのテキスト投稿` から「画像を送信してはならない (SHALL NOT)」制約を解除（MODIFIED）し、画像投稿要件を新規追加（ADDED）する。
+
+## MODIFIED Requirements
+
+### Requirement: Threads へのテキスト投稿（Post text to Threads）
+
+システムは、Threads が投稿対象に選択されているとき、入力テキストをバックエンド経由で Threads へ投稿しなければならない (SHALL)。バックエンドは、メディアコンテナ作成（`media_type=TEXT`）と公開（`creation_id` 指定）の 2 段階で投稿を行わなければならない (SHALL)。画像を添付して投稿する場合の振る舞いは `### Requirement: Threads への画像投稿` に従う。MVP ではリプライ先を Threads へ送信してはならない (SHALL NOT)。投稿に失敗した場合、システムは失敗を無言で握りつぶしてはならず (SHALL NOT)、エラー一覧に `Threads` を含めてユーザーへ通知しなければならない (SHALL)。
+
+#### Scenario: テキストを Threads に投稿する（Post text successfully）
+
+- **GIVEN** ユーザーが Threads に接続済みで、投稿対象チェックボックスが ON、本文が入力されている
+- **AND** 画像を添付していない
+- **WHEN** 投稿ボタンを押下する
+- **THEN** バックエンドがコンテナ作成（`media_type=TEXT`）→ 公開の 2 段階で投稿を完了する
+- **AND** Mastodon・Bluesky など他の選択中 SNS への投稿と並行して成功通知が表示される
+
+#### Scenario: 投稿に失敗する（Post fails）
+
+- **GIVEN** ユーザーが Threads を投稿対象に選択している
+- **AND** コンテナ作成または公開のいずれかが失敗する状態である
+- **WHEN** 投稿ボタンを押下する
+- **THEN** エラー一覧に `Threads` が含まれ、ユーザーへ投稿失敗が通知される
+
+## ADDED Requirements
+
+### Requirement: Threads への画像投稿（Post images to Threads）
+
+システムは、ユーザーが画像を添付して Threads 投稿を実行したとき、Supabase に一時保存された公開 URL を用いて Threads API に画像付き投稿を行わなければならない (SHALL)。
+
+画像が 1 枚の場合は `media_type=IMAGE` で単画像コンテナを作成し、2 枚以上の場合は各画像を `media_type=IMAGE` の子コンテナとして作成したうえで `media_type=CAROUSEL` の親コンテナにまとめなければならない (SHALL)。Threads API のカルーセル上限に合わせ、添付画像は最大 10 枚まで対応しなければならない (SHALL)。
+
+添付画像が 11 枚以上の場合、システムは Threads への投稿を試行してはならず (SHALL NOT)、Threads への投稿を失敗として扱い、エラー一覧に `Threads` を含めてユーザーへ通知しなければならない (SHALL)。
+
+バックエンドは `images` 配列が空または未指定の場合、PPP-009 のテキスト投稿フロー（`### Requirement: Threads へのテキスト投稿`）で処理しなければならない (SHALL)。
+
+#### Scenario: 単画像投稿（Single image post）
+
+- **GIVEN** ユーザーが本文と画像 1 枚を入力し、Threads にチェックを入れている
+- **WHEN** 投稿ボタンを押す
+- **THEN** `media_type=IMAGE` のコンテナが作成され、公開後に Threads タイムラインに画像付き投稿が表示される
+
+#### Scenario: 複数画像投稿（Multiple images post）
+
+- **GIVEN** ユーザーが本文と画像 3 枚を入力し、Threads にチェックを入れている
+- **WHEN** 投稿ボタンを押す
+- **THEN** 3 枚の `media_type=IMAGE` 子コンテナと 1 つの `media_type=CAROUSEL` 親コンテナが作成され、公開後にカルーセル投稿が表示される
+
+#### Scenario: テキストのみ投稿（Text only post）
+
+- **GIVEN** ユーザーが本文のみ入力し（画像なし）、Threads にチェックを入れている
+- **WHEN** 投稿ボタンを押す
+- **THEN** PPP-009 のテキスト投稿フロー（`media_type=TEXT`）で処理され、テキストのみ投稿が完了する
+
+#### Scenario: 上限を超える枚数の添付（Exceeds maximum image count）
+
+- **GIVEN** ユーザーが本文と画像 11 枚を入力し、Threads にチェックを入れている
+- **WHEN** 投稿ボタンを押す
+- **THEN** Threads への投稿は試行されず、失敗として扱われる
+- **AND** エラー一覧に `Threads` が含まれ、ユーザーへ投稿失敗が通知される
+
+### Requirement: Threads 画像投稿失敗時のエラー通知（Image post failure notification）
+
+システムは、画像付き Threads 投稿の多段フロー（子コンテナ作成・親コンテナ作成・公開）のいずれかが失敗した場合、失敗を無言で握りつぶしてはならず (SHALL NOT)、エラー一覧に `Threads` を含めてユーザーへ通知しなければならない (SHALL)。複数画像投稿時、子コンテナのいずれか 1 つでも作成に失敗した場合、システムはその投稿全体を失敗として扱わなければならない (SHALL)。
+
+#### Scenario: 子コンテナ作成失敗（Child container creation fails）
+
+- **GIVEN** ユーザーが本文と画像 3 枚を入力し、Threads にチェックを入れている
+- **AND** 3 枚のうち 1 枚の子コンテナ作成（`media_type=IMAGE`）が失敗する状態である
+- **WHEN** 投稿ボタンを押す
+- **THEN** 親コンテナ作成・公開は行われず、Threads 投稿が失敗として扱われる
+- **AND** エラー一覧に `Threads` が含まれ、ユーザーへ投稿失敗が通知される
+
+#### Scenario: 公開失敗（Publish fails）
+
+- **GIVEN** ユーザーが本文と画像 1 枚を入力し、Threads にチェックを入れている
+- **AND** コンテナ作成は成功するが公開（`threads_publish`）が失敗する状態である
+- **WHEN** 投稿ボタンを押す
+- **THEN** Threads 投稿が失敗として扱われる
+- **AND** エラー一覧に `Threads` が含まれ、ユーザーへ投稿失敗が通知される
+
+## Open Questions
+
+- Threads API の画像/カルーセルコンテナは作成直後に publish 可能とは限らず、`status` が `FINISHED` になるまでポーリングが推奨されている（IN_PROGRESS の状態でも作成 ID は返る）。MVP では作成直後に publish を試行し、失敗時は前述のエラー通知要件で処理する。安定性に問題が出た場合、publish 前のステータス確認（または短時間待機）を後続変更で導入するか検討する。

--- a/openspec/changes/PPP-010-add-threads-image-posting/tasks.md
+++ b/openspec/changes/PPP-010-add-threads-image-posting/tasks.md
@@ -2,26 +2,26 @@
 
 ## 1. バックエンド: 画像投稿（threads_post.js）
 
-- [ ] 1.1 `event.body` から body フィールド `images: string[]`（Supabase 公開 URL 配列）を受け取る（既存の body フィールド `user_id` / `token` / `text` と同階層）。以降、Threads API へ渡すパラメータ（`image_url` / `media_type` / `access_token`）とは区別する
-- [ ] 1.2 `images` が空または未指定の場合は既存のテキスト投稿フロー（`media_type=TEXT`）をそのまま実行する
-- [ ] 1.3 `images.length` が 11 以上の場合は Threads API を呼ばずにエラーステータスを返す（上限超過）
-- [ ] 1.4 `images` が 1 枚の場合: `POST /me/threads`（API パラメータ `media_type=IMAGE`, `image_url`, `text`, `access_token`）でコンテナを作成し、`POST /me/threads_publish`（`creation_id`, `access_token`）で公開する
-- [ ] 1.5 `images` が 2 枚以上 10 枚以下の場合:
+- [x] 1.1 `event.body` から body フィールド `images: string[]`（Supabase 公開 URL 配列）を受け取る（既存の body フィールド `user_id` / `token` / `text` と同階層）。以降、Threads API へ渡すパラメータ（`image_url` / `media_type` / `access_token`）とは区別する
+- [x] 1.2 `images` が空または未指定の場合は既存のテキスト投稿フロー（`media_type=TEXT`）をそのまま実行する
+- [x] 1.3 `images.length` が 11 以上の場合は Threads API を呼ばずにエラーステータスを返す（上限超過）
+- [x] 1.4 `images` が 1 枚の場合: `POST /me/threads`（API パラメータ `media_type=IMAGE`, `image_url`, `text`, `access_token`）でコンテナを作成し、`POST /me/threads_publish`（`creation_id`, `access_token`）で公開する
+- [x] 1.5 `images` が 2 枚以上 10 枚以下の場合:
   - 各画像で `POST /me/threads`（`media_type=IMAGE`, `image_url`, `access_token`）の子コンテナを並列作成し `creation_id` 一覧を得る。子コンテナのいずれか 1 つでも作成に失敗した場合は投稿全体を失敗として中断する
   - `POST /me/threads`（`media_type=CAROUSEL`, `children={ids}`, `text`, `access_token`）で親コンテナを作成する
   - `POST /me/threads_publish`（`creation_id`, `access_token`）で公開する
-- [ ] 1.6 子コンテナ作成・親コンテナ作成・公開・上限超過のいずれかが失敗した場合はエラーステータスを返し、フロントエンドがエラー一覧に `Threads` を含められるようにする
+- [x] 1.6 子コンテナ作成・親コンテナ作成・公開・上限超過のいずれかが失敗した場合はエラーステータスを返し、フロントエンドがエラー一覧に `Threads` を含められるようにする
 
 ## 2. フロントエンド: 投稿処理（MainContent.ts）
 
-- [ ] 2.1 `postToThreads(text: string, imageUrls: string[])` に `imageUrls` 引数を追加する
-- [ ] 2.2 `postToSns` の `case 'threads'` で `postToThreads(text, uploadedImageUrls)` と渡すよう変更する
-- [ ] 2.3 バックエンドへのリクエスト body に `images: imageUrls` を追加する（既存の body フィールド `user_id` / `token` / `text` と同階層）
-- [ ] 2.4 `postToThreads` が失敗（`false`）を返した場合、既存のエラー集約処理でエラー一覧に `Threads` を含める（上限超過・コンテナ作成失敗・公開失敗を含む）
+- [x] 2.1 `postToThreads(text: string, imageUrls: string[])` に `imageUrls` 引数を追加する
+- [x] 2.2 `postToSns` の `case 'threads'` で `postToThreads(text, uploadedImageUrls)` と渡すよう変更する
+- [x] 2.3 バックエンドへのリクエスト body に `images: imageUrls` を追加する（既存の body フィールド `user_id` / `token` / `text` と同階層）
+- [x] 2.4 `postToThreads` が失敗（`false`）を返した場合、既存のエラー集約処理でエラー一覧に `Threads` を含める（上限超過・コンテナ作成失敗・公開失敗を含む）
 
 ## 3. 動作検証
 
-- [ ] 3.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
+- [x] 3.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
 - [ ] 3.2 画像 1 枚付き投稿が Threads に反映されることを確認する
 - [ ] 3.3 画像 2 枚以上付き投稿がカルーセルとして Threads に反映されることを確認する
 - [ ] 3.4 テキストのみ投稿が従来通り動作することを確認する

--- a/openspec/changes/PPP-010-add-threads-image-posting/tasks.md
+++ b/openspec/changes/PPP-010-add-threads-image-posting/tasks.md
@@ -1,0 +1,30 @@
+# Implementation Tasks
+
+## 1. バックエンド: 画像投稿（threads_post.js）
+
+- [ ] 1.1 `event.body` から body フィールド `images: string[]`（Supabase 公開 URL 配列）を受け取る（既存の body フィールド `user_id` / `token` / `text` と同階層）。以降、Threads API へ渡すパラメータ（`image_url` / `media_type` / `access_token`）とは区別する
+- [ ] 1.2 `images` が空または未指定の場合は既存のテキスト投稿フロー（`media_type=TEXT`）をそのまま実行する
+- [ ] 1.3 `images.length` が 11 以上の場合は Threads API を呼ばずにエラーステータスを返す（上限超過）
+- [ ] 1.4 `images` が 1 枚の場合: `POST /me/threads`（API パラメータ `media_type=IMAGE`, `image_url`, `text`, `access_token`）でコンテナを作成し、`POST /me/threads_publish`（`creation_id`, `access_token`）で公開する
+- [ ] 1.5 `images` が 2 枚以上 10 枚以下の場合:
+  - 各画像で `POST /me/threads`（`media_type=IMAGE`, `image_url`, `access_token`）の子コンテナを並列作成し `creation_id` 一覧を得る。子コンテナのいずれか 1 つでも作成に失敗した場合は投稿全体を失敗として中断する
+  - `POST /me/threads`（`media_type=CAROUSEL`, `children={ids}`, `text`, `access_token`）で親コンテナを作成する
+  - `POST /me/threads_publish`（`creation_id`, `access_token`）で公開する
+- [ ] 1.6 子コンテナ作成・親コンテナ作成・公開・上限超過のいずれかが失敗した場合はエラーステータスを返し、フロントエンドがエラー一覧に `Threads` を含められるようにする
+
+## 2. フロントエンド: 投稿処理（MainContent.ts）
+
+- [ ] 2.1 `postToThreads(text: string, imageUrls: string[])` に `imageUrls` 引数を追加する
+- [ ] 2.2 `postToSns` の `case 'threads'` で `postToThreads(text, uploadedImageUrls)` と渡すよう変更する
+- [ ] 2.3 バックエンドへのリクエスト body に `images: imageUrls` を追加する（既存の body フィールド `user_id` / `token` / `text` と同階層）
+- [ ] 2.4 `postToThreads` が失敗（`false`）を返した場合、既存のエラー集約処理でエラー一覧に `Threads` を含める（上限超過・コンテナ作成失敗・公開失敗を含む）
+
+## 3. 動作検証
+
+- [ ] 3.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
+- [ ] 3.2 画像 1 枚付き投稿が Threads に反映されることを確認する
+- [ ] 3.3 画像 2 枚以上付き投稿がカルーセルとして Threads に反映されることを確認する
+- [ ] 3.4 テキストのみ投稿が従来通り動作することを確認する
+- [ ] 3.5 画像 11 枚添付時に Threads 投稿が失敗し、エラー一覧に `Threads` が含まれることを確認する
+- [ ] 3.6 子コンテナ作成・公開のいずれかが失敗した場合にエラー一覧に `Threads` が含まれることを確認する
+- [ ] 3.7 Mastodon・Bluesky への投稿が従来通り動作することを確認する


### PR DESCRIPTION
## Summary
- PPP-010: Threads への画像付き投稿（単画像・カルーセル）を実装
- `threads_post.js` に `images` 配列受け取りを追加し、単画像（`media_type=IMAGE`）・カルーセル（`media_type=CAROUSEL`）の 2 段階投稿フローを実装
- `MainContent.ts` の `postToThreads()` に `imageUrls` 引数を追加し、既存の Supabase 公開 URL フローを流用
- 11 枚以上添付時はエラー扱い、子コンテナ作成失敗時は投稿全体を中断

## Test plan
- [ ] 画像 1 枚付き投稿が Threads に反映される
- [ ] 画像 2 枚以上付き投稿がカルーセルとして Threads に反映される
- [ ] テキストのみ投稿が従来通り動作する
- [ ] 画像 11 枚添付時に Threads 投稿が失敗しエラー一覧に `Threads` が含まれる
- [ ] Mastodon・Bluesky への投稿が従来通り動作する

🤖 Generated with [Claude Code](https://claude.ai/code)