### PR TITLE
Threads 長命トークンの自動リフレッシュ

### DIFF
--- a/backend/netlify/functions/threads_refresh.js
+++ b/backend/netlify/functions/threads_refresh.js
@@ -1,0 +1,47 @@
+const fetch = require('node-fetch')
+
+const handler = async (event) => {
+  console.log(`start handler - `, event);
+
+  try {
+    const token = event.queryStringParameters.token ?? 'empty';
+
+    // 長命トークン（60 日）をリフレッシュ（client_secret 不要）
+    const refreshRes = await fetch(`https://graph.threads.net/refresh_access_token?grant_type=th_refresh_token&access_token=${token}`);
+
+    if (!refreshRes.ok) {
+      console.error(`refresh token request failed: ${refreshRes.status}`, await refreshRes.text());
+      return {
+        statusCode: refreshRes.status,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({ error: 'failed to refresh token' })
+      }
+    }
+
+    const refreshJson = await refreshRes.json();
+
+    const response = {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        access_token: refreshJson.access_token,
+        token_type: refreshJson.token_type,
+        expires_in: refreshJson.expires_in,
+      })
+    };
+    console.log(`finish handler - `, response);
+
+    return response;
+
+  } catch (error) {
+    console.log(`failed to refresh token:`, error);
+    return { statusCode: 500, body: error.toString() }
+  }
+}
+
+module.exports = { handler }

--- a/frontend/src/lib/MainContent.svelte
+++ b/frontend/src/lib/MainContent.svelte
@@ -162,6 +162,35 @@ onMount(async () => {
       history.replaceState(null, '', window.location.pathname);
     }
 
+    // Threads 長命トークンの自動リフレッシュ
+    // 接続済みかつ取得から 24 時間以上経過している場合のみリフレッシュする
+    const threadsSetting = loadPostSetting('threads');
+    if (threadsSetting != null) {
+      const REFRESH_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+      if (Date.now() - threadsSetting.token_data.obtained_at >= REFRESH_THRESHOLD_MS) {
+        try {
+          const refreshRes = await fetch(`${Config.API_ENDPOINT}/threads_refresh?token=${encodeURIComponent(threadsSetting.token_data.access_token)}`);
+          if (refreshRes.ok) {
+            const refreshJson = await refreshRes.json();
+            savePostSetting({
+              ...threadsSetting,
+              token_data: {
+                access_token: refreshJson.access_token,
+                token_type: refreshJson.token_type,
+                expires_in: refreshJson.expires_in,
+                obtained_at: Date.now(),
+              },
+            });
+            onChangePostSettings();
+          } else {
+            console.error(`failed to refresh threads token:`, refreshRes);
+          }
+        } catch (error) {
+          console.error(`failed to refresh threads token:`, error);
+        }
+      }
+    }
+
     const content = urlParams.get('text');
     const url = urlParams.get('url');
     let queryValueUsed: string | null = null;

--- a/openspec/changes/PPP-011-add-threads-token-refresh/proposal.md
+++ b/openspec/changes/PPP-011-add-threads-token-refresh/proposal.md
@@ -1,0 +1,34 @@
+# Threads 長命トークンの自動リフレッシュ
+
+## Why
+
+PPP-009（Threads テキスト投稿）で長命トークン（60 日）を取得・保存しているが、自動リフレッシュは Non-Goal として未実装だった。現状ではトークンが 60 日で失効し、ユーザーは手動で切断→再接続する必要がある。
+
+`SettingDataThreads.token_data` には期限判定用の `expires_in` / `obtained_at` が PPP-009 で用意済みであり（PPP-009 design.md で「後続で追加しやすくする」と明記）、これを活用して起動時の自動リフレッシュを実装する。ユーザーが 60 日以内に 1 回でもアプリを開けばトークンが維持されるようになる。
+
+本変更は PPP-009（Threads テキスト投稿）の完了を前提とする。
+
+## What Changes
+
+- `### Requirement: Threads 長命トークンの自動リフレッシュ`（ADDED）を追加し、起動時のリフレッシュ条件・保存・失敗時の挙動を定義する
+- `backend/netlify/functions/threads_refresh.js` を新規作成し、現在の長命トークンを `grant_type=th_refresh_token` で新しい 60 日トークンへ更新する
+- `frontend/src/lib/MainContent.svelte` の `onMount` に、取得から 24 時間以上経過したトークンのリフレッシュ処理を追加する
+
+## Non-Goals
+
+- 失効済みトークンの自動再認可（失効時は従来通りユーザーが手動で再接続する）
+- 投稿直前のリフレッシュ（起動時チェックのみ。Threads トークンは 60 日と長く、起動時更新で十分）
+- Mastodon・Bluesky のトークン管理変更
+
+## Impact
+
+- **Dependencies**: PPP-009（Threads テキスト投稿）の完了を前提とする
+- **Affected specs**: threads-posting（ADDED: 長命トークンの自動リフレッシュ）
+- **Affected code**:
+  - 新規: `backend/netlify/functions/threads_refresh.js`
+  - 変更: `frontend/src/lib/MainContent.svelte`
+- **Breaking changes**: なし（`token_data` の構造は既存のまま。接続・投稿フローに変更なし）
+
+## References
+
+- [実装計画](./references/plan-202606121000.md)

--- a/openspec/changes/PPP-011-add-threads-token-refresh/references/plan-202606121000.md
+++ b/openspec/changes/PPP-011-add-threads-token-refresh/references/plan-202606121000.md
@@ -1,0 +1,75 @@
+# PPP-011: Threads 長命トークンの自動リフレッシュ
+
+## Context
+
+PPP-009（Threads テキスト投稿）で長命トークン（60 日）を取得・保存しているが、自動リフレッシュは Non-Goal として未実装。現状ではトークンが 60 日で失効し、ユーザーは手動で切断→再接続が必要になる。`SettingDataThreads.token_data` には期限判定用の `expires_in` / `obtained_at` が既に用意されており（PPP-009 design.md で「後続で追加しやすくする」と明記）、これを活用してリフレッシュを実装する。
+
+## Threads API のリフレッシュ仕様
+
+- エンドポイント: `GET https://graph.threads.net/refresh_access_token?grant_type=th_refresh_token&access_token=<長命トークン>`
+- `client_secret` 不要（トークンのみで更新可能）
+- 制約: **取得から 24 時間以上経過**したトークンのみ更新可能。失効済みトークンは更新不可（再接続が必要）
+- レスポンス: `{ access_token, token_type, expires_in }`（新しい 60 日トークン）
+
+## 設計方針
+
+**リフレッシュ戦略**: アプリ起動時（`onMount`）にトークン年齢をチェックし、**24 時間以上経過していたら**バックエンド経由でリフレッシュする。
+
+- ユーザーが 60 日以内に 1 回でもアプリを開けばトークンが維持される
+- 失敗時は既存トークンを維持して投稿は通常通り試行（トークンがまだ有効な可能性が高いため）。失効していた場合は投稿失敗 → ユーザーが再接続（既存挙動）
+- Bluesky の「投稿後にセッション保存」パターンとは異なり、起動時チェックのみのシンプル構成とする（Threads は 60 日と長く、起動時更新で十分）
+
+## 作業手順（確立済みの OpenSpec フロー）
+
+### Step 1: OpenSpec proposal 作成（main 上で）
+
+`openspec/changes/PPP-011-add-threads-token-refresh/` を作成:
+
+- **proposal.md**: Why（60 日失効・手動再接続の解消）/ What Changes / Non-Goals（失効時の自動再認可、Mastodon・Bluesky のトークン管理変更）/ Impact
+- **specs/threads-posting/spec.md**: `## ADDED Requirements` で `### Requirement: Threads 長命トークンの自動リフレッシュ` を追加
+  - SHALL: 起動時に取得から 24 時間以上経過したトークンをバックエンド経由でリフレッシュし、新トークンと `obtained_at` を `ppp_setting_threads` に保存する
+  - SHALL NOT: リフレッシュ失敗時に既存トークンを削除しない（失効時の投稿失敗は既存のエラー通知要件で処理）
+  - Scenario: 24 時間経過後の起動でトークン更新 / 24 時間未満ではリフレッシュしない / リフレッシュ失敗時も接続状態を維持
+- **tasks.md**: 下記実装タスク
+
+### Step 2: レビューサイクル
+
+`/openspec-review-cycle` 相当（openspec-reviewer → openspec-designer を指摘ゼロまで、最大 10 回）
+
+### Step 3: コミット（ユーザー承認後）
+
+proposal を main にコミット
+
+### Step 4: 実装（openspec-ws-apply）
+
+worktree `../pppost-PPP-011` / ブランチ `feature/PPP-011` で実装 → PR 作成 → クリーンアップ
+
+## 実装内容（tasks.md の骨子）
+
+### バックエンド: `backend/netlify/functions/threads_refresh.js`（新規）
+
+- `threads_token.js` と同型（CORS ヘッダ、`errorResponse` パターン）
+- `GET ?token=<現在の長命トークン>` を受け、`https://graph.threads.net/refresh_access_token?grant_type=th_refresh_token&access_token=...` を呼ぶ
+- 成功時 `{ access_token, token_type, expires_in }` を返す。失敗時はエラーステータス
+- env 不要（client_secret 不要のため）
+
+### フロントエンド: `frontend/src/lib/MainContent.svelte`
+
+- `onMount` の Threads コールバック処理（138-163 行付近）の後に追加:
+  - `loadPostSetting('threads')` でトークンを読み、`Date.now() - token_data.obtained_at >= 24 * 60 * 60 * 1000` なら `GET ${Config.API_ENDPOINT}/threads_refresh?token=...` を呼ぶ
+  - 成功時: `savePostSetting` で新しい `token_data`（`obtained_at: Date.now()`）を保存し `onChangePostSettings()` を呼ぶ
+  - 失敗時: `console.error` のみ（既存トークン維持）
+
+### 変更しないもの
+
+- `func.ts` の型（`token_data` 構造は既存のまま流用）
+- `ThreadsConnection.svelte`（接続/切断 UI に変更なし）
+- `MainContent.ts`（投稿処理に変更なし）
+
+## 検証
+
+1. `cd frontend && npm run build` が型エラーなく成功
+2. localStorage の `ppp_setting_threads` の `obtained_at` を 25 時間前に書き換えてリロード → `threads_refresh` が呼ばれ `access_token` / `obtained_at` が更新されることを DevTools で確認
+3. `obtained_at` が現在時刻に近い状態でリロード → リフレッシュが呼ばれないことを確認
+4. リフレッシュ後に Threads へテキスト投稿が成功することを確認（トークン有効性の実地検証）
+5. Mastodon・Bluesky への投稿が従来通り動作することを確認

--- a/openspec/changes/PPP-011-add-threads-token-refresh/references/reviews/spec/spec-review-202606121654.md
+++ b/openspec/changes/PPP-011-add-threads-token-refresh/references/reviews/spec/spec-review-202606121654.md
@@ -1,0 +1,69 @@
+# Review: PPP-011-add-threads-token-refresh
+
+- **Date**: 2026/06/12 16:54 JST
+- **Reviewer**: openspec-reviewer
+- **Model**: claude-opus-4-8[1m]
+- **Iteration**: 1 / 10
+- **Result**: PASS
+
+## Summary
+
+Threads 長命トークンの起動時自動リフレッシュを ADDED 要件として定義した proposal。`openspec validate --strict` はパスし、plan.md・既存 spec・実装ファイルとの整合も取れている。Critical/Major の指摘はなく、Minor 指摘 2 件のみ。
+
+## Issues
+
+### Issue 1: リフレッシュ呼び出しの実行タイミングと OAuth コールバック直後の二重判定が spec で明示されていない
+- **Severity**: Minor
+- **Location**: `specs/threads-posting/spec.md`（Requirement 本文）、`tasks.md` 2.1
+- **Description**: tasks 2.1 では「Threads OAuth コールバック処理の後に」リフレッシュ処理を追加するとしている。接続直後（`obtained_at = Date.now()`）はコールバック処理内で保存されるため、その直後にリフレッシュ判定が走っても 24 時間未満として呼ばれない設計になっており実害はない。ただし spec 側には「接続直後の同一起動でリフレッシュが走らない」ことが明示されておらず、「24 時間未満ではリフレッシュしない」シナリオで暗黙にカバーされている状態。テスト観点としては成立するため Minor。
+- **Suggestion**: 必須ではないが、Requirement 本文に「リフレッシュ判定は OAuth コールバック処理の完了後に行う」旨を 1 文補足すると処理経路がより明確になる。
+
+### Issue 2: `expires_in` を期限判定に用いず `obtained_at` の経過時間のみで判定している根拠が spec に残っていない
+- **Severity**: Minor
+- **Location**: `specs/threads-posting/spec.md`（Requirement 本文）
+- **Description**: Why では `expires_in` / `obtained_at` の両方を「期限判定用」として挙げているが、実際の判定条件は `obtained_at` からの経過 24 時間のみで、`expires_in`（60 日）は判定に使われていない。これは Threads API のリフレッシュ制約（取得後 24 時間以上経過が必須／60 日以内なら更新可）に基づく妥当な設計だが、「なぜ `expires_in` を判定に使わないのか」が spec/proposal に残っておらず、後続実装者が誤って `expires_in` ベースの判定を入れる懸念がわずかにある。
+- **Suggestion**: Requirement 本文または proposal の Non-Goals 付近に「リフレッシュ可否は取得後経過時間（24 時間〜60 日）で決まるため `expires_in` は失効表示用途のみ」と 1 行補足するとよい。
+
+## Checklist
+
+### A. フォーマット検証
+- [x] Requirement に SHALL/MUST が含まれている（SHALL / SHALL NOT を使用）
+- [x] 各 Requirement に Scenario がある（4 シナリオ）
+- [x] MODIFIED 要件に元の内容が完全に記載（本 proposal は ADDED のみのため N/A）
+- [x] proposal.md に Why/What Changes/Impact がある
+- [x] openspec validate --strict がパス（`Change 'PPP-011-add-threads-token-refresh' is valid`）
+
+### B0. Plan ↔ Proposal/Spec 整合性
+- [x] plan.md の各項目が proposal に反映されている（API 仕様・設計方針・実装内容が proposal/tasks へ反映）
+- [x] plan.md の決定事項が spec の Requirement になっている（24 時間判定・失敗時維持・client_secret 不使用）
+- [x] plan.md の設計判断が保持されている（起動時チェックのみ・Bluesky パターンとの差異・失敗時投稿継続）
+- [x] スコープが一致している（Non-Goals: 失効時自動再認可・投稿直前リフレッシュ・Mastodon/Bluesky 変更）
+
+### B. 内容面レビュー
+- [x] 要件間に矛盾がない（PPP-010 は「テキスト投稿」MODIFIED ＋「画像投稿」ADDED、本変更は独立した ADDED 要件でデルタ衝突なし）
+- [x] 曖昧な表現がない（「適切に」「必要に応じて」等なし。閾値は `24 * 60 * 60 * 1000` ms と具体値）
+- [x] シナリオがテスト可能（24h 経過/未満/失敗/未接続の 4 ケースが GIVEN-WHEN-THEN で具体化）
+- [x] エッジケース・エラーケースが網羅されている（リフレッシュ失敗・未接続・失効後の投稿失敗委譲をカバー）
+- [x] 影響範囲が妥当（新規 threads_refresh.js / MainContent.svelte 変更のみ。func.ts 型・接続 UI は不変更を明記）
+- [x] ビジネスロジックが整合（失敗時は既存トークン維持＝まだ有効な可能性が高く投稿継続できる設計が合理的）
+- [x] プロジェクトドキュメントと整合（`ppp_setting_threads`・`token_data` 構造・`loadPostSetting` null 返却・`Config.API_ENDPOINT` いずれも実装と一致）
+- [x] Spec ↔ Proposal 整合: proposal の意図が spec で網羅されている
+- [x] Spec ↔ Proposal 整合: 暗黙の前提が spec で明文化されている（接続状態維持・「接続済み」表示の維持を AND 句で明示）
+- [x] Spec ↔ Proposal 整合: 処理経路が完結している（リフレッシュ→保存→`onChangePostSettings` 反映までユーザー知覚経路が定義済み）
+
+### C. ドメイン境界変更の影響分析
+- [x] API フィールド追加の影響を確認（該当なし: `token_data` 構造は既存のまま、新フィールド追加なし）
+- [x] DB 列値追加の影響を確認（該当なし: DB なし、localStorage のみ）
+- [x] 定数追加の影響を確認（該当なし）
+- [x] テーブルへの新規レコードの影響を確認（該当なし）
+
+### D. タスク計画レビュー
+- [x] 各 Requirement に対応するタスクがある（リフレッシュ条件→1.2/2.3、保存→2.4、失敗時維持→2.5、未接続→2.2）
+- [x] 各 Scenario を検証するタスクがある（3.2=24h 経過、3.3=24h 未満、3.5=未接続、3.4=失敗後の有効性確認）
+- [x] タスクに対象ファイルが明記されている（threads_refresh.js / MainContent.svelte）
+- [x] タスクの順序が依存関係を考慮している（バックエンド→フロント→検証）
+- [x] 検証/テストタスクが含まれている（3.1〜3.6、Mastodon/Bluesky リグレッション含む）
+
+## Conclusion
+
+この proposal は OpenSpec の品質基準を満たしており、実装に進めることを推奨します。Minor 指摘 2 件は補足推奨レベルであり、PASS をブロックしません。

--- a/openspec/changes/PPP-011-add-threads-token-refresh/specs/threads-posting/spec.md
+++ b/openspec/changes/PPP-011-add-threads-token-refresh/specs/threads-posting/spec.md
@@ -1,0 +1,49 @@
+# Threads Posting Specification
+
+## Overview
+
+Threads 長命トークン（60 日）の自動リフレッシュ要件を追加する。PPP-009 で保存している `token_data`（`access_token`, `token_type`, `expires_in`, `obtained_at`）を活用し、アプリ起動時にトークンを更新する。
+
+## ADDED Requirements
+
+### Requirement: Threads 長命トークンの自動リフレッシュ（Auto-refresh long-lived token）
+
+システムは、アプリ起動時に Threads の長命トークンが取得から 24 時間以上経過している場合、バックエンド経由で Threads API（`grant_type=th_refresh_token`）を呼び出してトークンをリフレッシュしなければならない (SHALL)。Threads API の制約により、取得から 24 時間未満のトークンをリフレッシュしてはならない (SHALL NOT)。
+
+リフレッシュに成功した場合、システムは新しい `access_token` / `token_type` / `expires_in` と更新時刻（`obtained_at`）を `localStorage` キー `ppp_setting_threads` の `token_data` へ保存しなければならない (SHALL)。
+
+リフレッシュに失敗した場合、システムは既存のトークンと接続状態を維持しなければならず (SHALL)、保存済みトークンを削除してはならない (SHALL NOT)。失効済みトークンによる投稿失敗は、既存のエラー通知要件（エラー一覧に `Threads` を含めて通知）で処理する。
+
+`client_secret` をフロントエンドで扱ってはならない (SHALL NOT)（リフレッシュ API は `client_secret` 不要だが、呼び出しは既存構成に合わせてバックエンド経由とする）。
+
+リフレッシュ可否の判定は `obtained_at` からの経過時間のみで行う（`expires_in` は判定に使用しない）。Threads API の制約が「取得から 24 時間以上経過」であるため、残り寿命ではなく経過時間が判定基準となる。OAuth 接続直後の起動では経過時間が 24 時間未満のため、リフレッシュは自然に行われない。
+
+#### Scenario: 24 時間経過後の起動でトークンが更新される（Refresh on launch after 24 hours）
+
+- **GIVEN** ユーザーが Threads に接続済みで、`token_data.obtained_at` から 24 時間以上経過している
+- **WHEN** アプリを起動する
+- **THEN** バックエンド経由で Threads API のリフレッシュが呼び出される
+- **AND** 新しい `access_token` と更新後の `obtained_at` が `ppp_setting_threads` に保存される
+- **AND** Threads は「接続済み」のまま表示される
+
+#### Scenario: 24 時間未満ではリフレッシュしない（No refresh within 24 hours）
+
+- **GIVEN** ユーザーが Threads に接続済みで、`token_data.obtained_at` から 24 時間未満である
+- **WHEN** アプリを起動する
+- **THEN** リフレッシュ API は呼び出されない
+- **AND** `token_data` は変更されない
+
+#### Scenario: リフレッシュ失敗時も接続状態を維持する（Keep connection on refresh failure）
+
+- **GIVEN** ユーザーが Threads に接続済みで、`token_data.obtained_at` から 24 時間以上経過している
+- **AND** リフレッシュ API が失敗する状態である（ネットワークエラーやトークン失効など）
+- **WHEN** アプリを起動する
+- **THEN** 既存の `token_data` が維持され、削除されない
+- **AND** Threads は「接続済み」のまま表示される
+- **AND** トークンが失効していた場合、投稿時にエラー一覧へ `Threads` が含まれて通知される（既存要件）
+
+#### Scenario: 未接続時は何もしない（No-op when not connected）
+
+- **GIVEN** ユーザーが Threads に接続していない（`ppp_setting_threads` が存在しない）
+- **WHEN** アプリを起動する
+- **THEN** リフレッシュ API は呼び出されない

--- a/openspec/changes/PPP-011-add-threads-token-refresh/tasks.md
+++ b/openspec/changes/PPP-011-add-threads-token-refresh/tasks.md
@@ -2,22 +2,22 @@
 
 ## 1. バックエンド: トークンリフレッシュ（threads_refresh.js）
 
-- [ ] 1.1 `backend/netlify/functions/threads_refresh.js` を新規作成する（`threads_token.js` 同型、CORS ヘッダ対応）
-- [ ] 1.2 `GET ?token=<現在の長命トークン>` を受け、`GET https://graph.threads.net/refresh_access_token?grant_type=th_refresh_token&access_token=<token>` を呼ぶ（`client_secret` 不要のため env 追加なし）
-- [ ] 1.3 成功時 `{ access_token, token_type, expires_in }` を CORS ヘッダ付きで返す
-- [ ] 1.4 失敗時はエラーステータスを返し、エラー内容を `console.error` でログ出力する
+- [x] 1.1 `backend/netlify/functions/threads_refresh.js` を新規作成する（`threads_token.js` 同型、CORS ヘッダ対応）
+- [x] 1.2 `GET ?token=<現在の長命トークン>` を受け、`GET https://graph.threads.net/refresh_access_token?grant_type=th_refresh_token&access_token=<token>` を呼ぶ（`client_secret` 不要のため env 追加なし）
+- [x] 1.3 成功時 `{ access_token, token_type, expires_in }` を CORS ヘッダ付きで返す
+- [x] 1.4 失敗時はエラーステータスを返し、エラー内容を `console.error` でログ出力する
 
 ## 2. フロントエンド: 起動時リフレッシュ（MainContent.svelte）
 
-- [ ] 2.1 `onMount` の Threads OAuth コールバック処理の後に、トークンリフレッシュ処理を追加する
-- [ ] 2.2 `loadPostSetting('threads')` で設定を読み、未接続（null）の場合は何もしない
-- [ ] 2.3 `Date.now() - token_data.obtained_at >= 24 * 60 * 60 * 1000` の場合のみ `GET ${Config.API_ENDPOINT}/threads_refresh?token=<access_token>` を呼ぶ
-- [ ] 2.4 成功時: レスポンスの `access_token` / `token_type` / `expires_in` と `obtained_at: Date.now()` で `token_data` を更新し、`savePostSetting` で保存して `onChangePostSettings()` を呼ぶ
-- [ ] 2.5 失敗時: `console.error` のみとし、既存の `token_data` を維持する（削除しない）
+- [x] 2.1 `onMount` の Threads OAuth コールバック処理の後に、トークンリフレッシュ処理を追加する
+- [x] 2.2 `loadPostSetting('threads')` で設定を読み、未接続（null）の場合は何もしない
+- [x] 2.3 `Date.now() - token_data.obtained_at >= 24 * 60 * 60 * 1000` の場合のみ `GET ${Config.API_ENDPOINT}/threads_refresh?token=<access_token>` を呼ぶ
+- [x] 2.4 成功時: レスポンスの `access_token` / `token_type` / `expires_in` と `obtained_at: Date.now()` で `token_data` を更新し、`savePostSetting` で保存して `onChangePostSettings()` を呼ぶ
+- [x] 2.5 失敗時: `console.error` のみとし、既存の `token_data` を維持する（削除しない）
 
 ## 3. 動作検証
 
-- [ ] 3.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
+- [x] 3.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
 - [ ] 3.2 localStorage の `ppp_setting_threads` の `obtained_at` を 25 時間前に書き換えてリロードし、`threads_refresh` が呼ばれて `access_token` / `obtained_at` が更新されることを DevTools で確認する
 - [ ] 3.3 `obtained_at` が現在時刻に近い状態でリロードし、リフレッシュ API が呼ばれないことを確認する
 - [ ] 3.4 リフレッシュ後に Threads へテキスト投稿が成功することを確認する（新トークンの有効性検証）

--- a/openspec/changes/PPP-011-add-threads-token-refresh/tasks.md
+++ b/openspec/changes/PPP-011-add-threads-token-refresh/tasks.md
@@ -1,0 +1,25 @@
+# Implementation Tasks
+
+## 1. バックエンド: トークンリフレッシュ（threads_refresh.js）
+
+- [ ] 1.1 `backend/netlify/functions/threads_refresh.js` を新規作成する（`threads_token.js` 同型、CORS ヘッダ対応）
+- [ ] 1.2 `GET ?token=<現在の長命トークン>` を受け、`GET https://graph.threads.net/refresh_access_token?grant_type=th_refresh_token&access_token=<token>` を呼ぶ（`client_secret` 不要のため env 追加なし）
+- [ ] 1.3 成功時 `{ access_token, token_type, expires_in }` を CORS ヘッダ付きで返す
+- [ ] 1.4 失敗時はエラーステータスを返し、エラー内容を `console.error` でログ出力する
+
+## 2. フロントエンド: 起動時リフレッシュ（MainContent.svelte）
+
+- [ ] 2.1 `onMount` の Threads OAuth コールバック処理の後に、トークンリフレッシュ処理を追加する
+- [ ] 2.2 `loadPostSetting('threads')` で設定を読み、未接続（null）の場合は何もしない
+- [ ] 2.3 `Date.now() - token_data.obtained_at >= 24 * 60 * 60 * 1000` の場合のみ `GET ${Config.API_ENDPOINT}/threads_refresh?token=<access_token>` を呼ぶ
+- [ ] 2.4 成功時: レスポンスの `access_token` / `token_type` / `expires_in` と `obtained_at: Date.now()` で `token_data` を更新し、`savePostSetting` で保存して `onChangePostSettings()` を呼ぶ
+- [ ] 2.5 失敗時: `console.error` のみとし、既存の `token_data` を維持する（削除しない）
+
+## 3. 動作検証
+
+- [ ] 3.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
+- [ ] 3.2 localStorage の `ppp_setting_threads` の `obtained_at` を 25 時間前に書き換えてリロードし、`threads_refresh` が呼ばれて `access_token` / `obtained_at` が更新されることを DevTools で確認する
+- [ ] 3.3 `obtained_at` が現在時刻に近い状態でリロードし、リフレッシュ API が呼ばれないことを確認する
+- [ ] 3.4 リフレッシュ後に Threads へテキスト投稿が成功することを確認する（新トークンの有効性検証）
+- [ ] 3.5 未接続状態（`ppp_setting_threads` なし）でリロードし、リフレッシュ API が呼ばれないことを確認する
+- [ ] 3.6 Mastodon・Bluesky への投稿が従来通り動作することを確認する


### PR DESCRIPTION
## Summary
- PPP-011: Threads 長命トークン（60 日）のアプリ起動時自動リフレッシュを実装
- `threads_refresh.js` 新規作成（`grant_type=th_refresh_token` でトークン更新、client_secret 不要）
- `MainContent.svelte` の `onMount` に、取得から 24 時間以上経過したトークンのリフレッシュ処理を追加
- リフレッシュ失敗時は既存トークンを維持（接続状態を壊さない）

## Test plan
- [ ] localStorage の `obtained_at` を 25 時間前に書き換えてリロードし、トークンが更新される
- [ ] `obtained_at` が 24 時間未満ではリフレッシュ API が呼ばれない
- [ ] リフレッシュ後に Threads へテキスト投稿が成功する
- [ ] 未接続時はリフレッシュ API が呼ばれない
- [ ] Mastodon・Bluesky への投稿が従来通り動作する

🤖 Generated with [Claude Code](https://claude.ai/code)