### PR TITLE
Reply の Threads 対応

### DIFF
--- a/backend/netlify/functions/threads_post.js
+++ b/backend/netlify/functions/threads_post.js
@@ -67,8 +67,13 @@ const handler = async (event) => {
   }
 
   try {
-    const { user_id, token, text, images } = JSON.parse(event.body);
+    const { user_id, token, text, images, reply_to_id } = JSON.parse(event.body);
     const imageUrls = Array.isArray(images) ? images : [];
+
+    // リプライ投稿時のみトップレベルコンテナに付与する追加パラメータ
+    const replyParams = (reply_to_id != null && reply_to_id !== '')
+      ? { reply_to_id }
+      : {};
 
     // 上限超過: Threads API を呼ばずにエラーを返す
     if (imageUrls.length > MAX_IMAGES) {
@@ -84,6 +89,7 @@ const handler = async (event) => {
         media_type: 'TEXT',
         text,
         access_token: token,
+        ...replyParams,
       });
       if (creation_id == null) {
         return errorResponse(500, 'failed to create threads container');
@@ -95,6 +101,7 @@ const handler = async (event) => {
         image_url: imageUrls[0],
         text,
         access_token: token,
+        ...replyParams,
       });
       if (creation_id == null) {
         return errorResponse(500, 'failed to create threads container');
@@ -123,6 +130,7 @@ const handler = async (event) => {
         children: childIds.join(','),
         text,
         access_token: token,
+        ...replyParams,
       });
       if (creation_id == null) {
         return errorResponse(500, 'failed to create threads carousel container');

--- a/backend/netlify/functions/threads_posts.js
+++ b/backend/netlify/functions/threads_posts.js
@@ -1,0 +1,56 @@
+const fetch = require('node-fetch')
+
+const THREADS_API_BASE = 'https://graph.threads.net/v1.0';
+
+const handler = async (event) => {
+  // CORS対応
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      },
+      body: '',
+    };
+  }
+
+  try {
+    const { token } = JSON.parse(event.body);
+
+    // 自分の投稿一覧を取得（reply 元候補）
+    const url = `${THREADS_API_BASE}/me/threads?fields=id,text,permalink,timestamp&limit=25&access_token=${encodeURIComponent(token)}`;
+    const res = await fetch(url);
+
+    if (!res.ok) {
+      console.error(`threads posts fetch failed: ${res.status}`, await res.text());
+      return { statusCode: res.status, body: 'failed to fetch threads posts' };
+    }
+
+    const json = await res.json();
+    const posts = Array.isArray(json.data) ? json.data : [];
+
+    const results = posts.map((p) => ({
+      id: p.id,
+      text: p.text,
+      url: p.permalink,
+      posted_at: p.timestamp,
+    }));
+
+    const response = {
+      statusCode: 200,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify(results)
+    };
+    console.info('posts threads succeeded', response);
+    return response;
+  } catch (error) {
+    console.error(`handler -> error:`, error);
+    return { statusCode: 500, body: error.toString() }
+  }
+}
+
+module.exports = { handler }

--- a/frontend/src/lib/MainContent.svelte
+++ b/frontend/src/lib/MainContent.svelte
@@ -308,6 +308,9 @@ const post = async () => {
     const res = await postToSns(text, urlsToPost, { reply_to_ids: {
       mastodon: getPostId(replyToPost?.postOfType['mastodon']?.url ?? replyToIdForMastodon),
       bluesky: getPostId(replyToPost?.postOfType['bluesky']?.url ?? replyToIdForBluesky),
+      // Threads は permalink 末尾がショートコードで API の投稿 ID と異なるため、
+      // getPostId は使わず取得済みの id をそのまま使用する（design.md D1）
+      threads: replyToPost?.postOfType['threads']?.id ?? '',
     } });
 
     if (res.errors.length == 0) {

--- a/frontend/src/lib/MainContent.ts
+++ b/frontend/src/lib/MainContent.ts
@@ -4,7 +4,7 @@ import type { AtpSessionData } from "@atproto/api";
 import dayjs from "dayjs";
 import { uploadImageToSupabase, deleteImagesFromSupabase } from "./supabase-client";
 
-export type Post = { text: string, url: string, posted_at: Date };
+export type Post = { text: string, url: string, posted_at: Date, id?: string };
 export type PresentedPost = {
   display_posted_at: string | undefined,
   trimmed_text: string,
@@ -67,6 +67,9 @@ export const loadMyPosts = async (): Promise<PresentedPost[]> => {
       break;
     case 'bluesky':
       promises.push(loadMyPostsBluesky().then(posts => ({ type: 'bluesky', posts })));
+      break;
+    case 'threads':
+      promises.push(loadMyPostsThreads().then(posts => ({ type: 'threads', posts })));
       break;
     }
   }
@@ -160,6 +163,7 @@ export const loadMyPosts = async (): Promise<PresentedPost[]> => {
 export const postToSns = async (text: string, imageDataURLs: string[], options: { reply_to_ids: {
   mastodon: string,
   bluesky: string,
+  threads: string,
 }}): Promise<{ errors: string[] }> => {
   const errors: string[] = [];
 
@@ -195,7 +199,7 @@ export const postToSns = async (text: string, imageDataURLs: string[], options: 
       promises.push(postToBluesky(text, uploadedImageUrls, options?.reply_to_ids?.bluesky).then((r) => { if (!r) errors.push('Bluesky') }));
       break;
     case 'threads':
-      promises.push(postToThreads(text, uploadedImageUrls).then((r) => { if (!r) errors.push('Threads') }));
+      promises.push(postToThreads(text, uploadedImageUrls, options?.reply_to_ids?.threads).then((r) => { if (!r) errors.push('Threads') }));
       break;
     }
 
@@ -274,7 +278,7 @@ const postToMastodon = async (text: string, imageUrls: string[], reply_to_id: st
 };  
 
 
-const postToThreads = async (text: string, imageUrls: string[]): Promise<boolean> => {
+const postToThreads = async (text: string, imageUrls: string[], reply_to_id?: string): Promise<boolean> => {
   try {
     const settings = postSettings.threads!;
 
@@ -288,6 +292,7 @@ const postToThreads = async (text: string, imageUrls: string[]): Promise<boolean
         token: settings.token_data.access_token,
         text,
         images: imageUrls,
+        reply_to_id,
       }),
     });
 
@@ -295,6 +300,31 @@ const postToThreads = async (text: string, imageUrls: string[]): Promise<boolean
   } catch (error) {
     console.error(`postToThreads -> error:`, error);
     return false;
+  }
+};
+
+const loadMyPostsThreads = async (): Promise<Post[]> => {
+  try {
+    const settings = postSettings.threads!;
+    const token = settings.token_data.access_token;
+
+    const res = await fetch(`${Config.API_ENDPOINT}/threads_posts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ token }),
+    });
+
+    if (res.ok) {
+      const resJson = await res.json();
+      return resJson;
+    } else {
+      return [];
+    }
+  } catch (error) {
+    console.error(`loadMyPostsThreads -> error:`, error);
+    return [];
   }
 };
 

--- a/openspec/changes/PPP-012-add-threads-reply/design.md
+++ b/openspec/changes/PPP-012-add-threads-reply/design.md
@@ -1,0 +1,29 @@
+# Design: Reply の Threads 対応
+
+## D1: reply_to_id は API の投稿 ID を使用（permalink から導出しない）
+
+Mastodon・Bluesky は投稿 URL の末尾セグメントが API の投稿 ID と一致するため、既存実装は `getPostId()` で URL から ID を抽出している。
+
+**Threads はこのパターンが使えない**。permalink（`https://www.threads.net/@{user}/post/{shortcode}`）の末尾はショートコードであり、リプライ作成時の `reply_to_id` に必要な数値の投稿 ID とは異なる。
+
+対応: 自投稿取得 API（`GET /me/threads?fields=id,text,permalink,timestamp`）が返す `id` をフロントの `Post` 型に保持し（`id?: string` をオプショナル追加）、リプライ投稿時は `replyToPost.postOfType['threads'].id` を直接使用する。`getPostId()` は Threads には適用しない。
+
+この制約により、Threads の手動リプライ ID 入力欄は設けない（ユーザーが投稿 ID を知る手段がないため）。
+
+## D2: リプライ投稿の API 呼び出し
+
+リプライはコンテナ作成（`POST /me/threads`）に `reply_to_id` パラメータを追加するだけで、公開（`threads_publish`)以降のフローは通常投稿と同一。テキスト・単画像・カルーセルのいずれでも、トップレベルのコンテナ（カルーセルの場合は親コンテナ）に `reply_to_id` を付与する。
+
+## D3: 必要スコープの検証（Open Question）
+
+自投稿取得（`GET /me/threads`）は既存の `threads_basic` スコープで可能。
+
+リプライ作成は `threads_content_publish` で可能と想定するが、Meta のドキュメントには Reply Management API として `threads_manage_replies` の記載もあり、自投稿へのリプライ作成にどこまで要求されるかはドキュメント上明確でない。実機検証で権限エラー（PPP-009 で経験した `code: 100, error_subcode: 10` 系）が発生した場合は、`ThreadsConnection.svelte` の認可 URL の `scope` に `threads_manage_replies` を追加し、ユーザーに再接続を促す（tasks.md に検証タスクとして明記）。
+
+## D4: 自投稿取得のバックエンド API 形式
+
+既存の `mastodon_posts.js` のパターン（POST で認証情報を受け、`{ text, url, posted_at }[]` を返す）を踏襲する:
+
+- リクエスト: `POST /threads_posts`、body `{ token }`（`user_id` は不要。`/me/threads` がトークンから解決）
+- レスポンス: `{ id, text, url, posted_at }[]`（`url` は permalink。`id` は D1 のため必須で返す）
+- 取得件数は他 SNS と同程度（25 件目安）とし、`limit` パラメータで指定する

--- a/openspec/changes/PPP-012-add-threads-reply/proposal.md
+++ b/openspec/changes/PPP-012-add-threads-reply/proposal.md
@@ -1,0 +1,41 @@
+# Reply の Threads 対応
+
+## Why
+
+Mastodon・Bluesky では自投稿を取得してリプライ元として選択し、リプライ投稿できるが、Threads は PPP-009 で「自投稿取得・リプライ元選択」を Non-Goal としたため未対応のままである。Threads でも同様にリプライできるようにし、マルチ SNS 投稿体験を統一する。
+
+threads-posting 正式 spec のテキスト投稿要件には「MVP ではリプライ先を Threads へ送信してはならない (SHALL NOT)」という制約があるため、本変更ではこの制約を解除する。
+
+本変更は PPP-009〜PPP-011（いずれもアーカイブ済み）の完了を前提とする。
+
+## What Changes
+
+- threads-posting spec の `### Requirement: Threads へのテキスト投稿` を MODIFIED で取り込み、「リプライ先を送信してはならない (SHALL NOT)」制約を解除する
+- `### Requirement: Threads の自投稿取得`（ADDED）を追加し、リプライ元候補として自投稿を取得・表示する要件を定義する
+- `### Requirement: Threads へのリプライ投稿`（ADDED）を追加し、`reply_to_id` によるリプライ投稿と ID の取り扱い（permalink からの導出禁止）を定義する
+- PPP-004-reply-selection spec のグループ化要件を MODIFIED し、対象 SNS に Threads を加える（あわせて、PPP-006 で投稿機能を廃除済みの X を対象 SNS の記載から削除する）
+- `backend/netlify/functions/threads_posts.js` を新規作成し、`GET /v1.0/me/threads`（`fields=id,text,permalink,timestamp`）で自投稿を取得する
+- `backend/netlify/functions/threads_post.js` に `reply_to_id` 受け取りを追加し、コンテナ作成時に Threads API へ渡す
+- `frontend/src/lib/MainContent.ts`: `Post` 型に `id?: string` を追加、`loadMyPostsThreads()` 新規作成、`loadMyPosts` の対象に Threads を追加、`postToThreads()` に `reply_to_id` 引数を追加、`postToSns` の `reply_to_ids` に `threads` を追加
+- `frontend/src/lib/MainContent.svelte`: 投稿時に `reply_to_ids.threads` を選択中の自投稿の `id` から構築する
+
+## Non-Goals
+
+- Threads 用の手動リプライ ID 入力欄（Threads の permalink からは API の投稿 ID を導出できないため、自投稿選択のみ対応。Mastodon・Bluesky の手動入力欄は従来通り）
+- 他人の投稿へのリプライ、リプライの閲覧・管理（`threads_read_replies` / `threads_manage_replies` を要する機能）
+- タイムライン取得
+
+## Impact
+
+- **Dependencies**: PPP-009（テキスト投稿）・PPP-010（画像投稿）・PPP-011（トークンリフレッシュ）の完了を前提とする（すべてアーカイブ済み）
+- **Affected specs**:
+  - threads-posting（MODIFIED: テキスト投稿要件 / ADDED: 自投稿取得・リプライ投稿）
+  - PPP-004-reply-selection（MODIFIED: グループ化対象 SNS に Threads を追加）
+- **Affected code**:
+  - 新規: `backend/netlify/functions/threads_posts.js`
+  - 変更: `backend/netlify/functions/threads_post.js`, `frontend/src/lib/MainContent.ts`, `frontend/src/lib/MainContent.svelte`
+- **Breaking changes**: なし（リプライ未選択時の投稿・他 SNS の動作は従来通り）
+
+## References
+
+- [design.md](./design.md) - reply_to_id の ID 種別、必要スコープの検証方針

--- a/openspec/changes/PPP-012-add-threads-reply/references/reviews/spec/spec-review-202606121817.md
+++ b/openspec/changes/PPP-012-add-threads-reply/references/reviews/spec/spec-review-202606121817.md
@@ -1,0 +1,66 @@
+# Review: PPP-012-add-threads-reply
+
+- **Date**: 2026/06/12 18:17 JST
+- **Reviewer**: openspec-reviewer
+- **Model**: claude-opus-4-8[1m]
+- **Iteration**: 1 / 10
+- **Result**: PASS
+
+## Summary
+
+Threads のリプライ対応 proposal。`openspec validate --strict` はパスし、MODIFIED 要件名は両 spec とも正式版と完全一致、design.md の決定事項（D1/D3）も spec・tasks へ正しく反映されている。実装実態（X 非対応、Post 型に id なし、reply_to_ids が mastodon/bluesky のみ）とも整合しており、品質基準を満たす。指摘は Minor 2 件のみ。
+
+## Issues
+
+### Issue 1: PPP-004 delta の Scenario からの `X` 削除が proposal に明記されていない
+- **Severity**: Minor
+- **Location**: `proposal.md`（line 16）/ `specs/PPP-004-reply-selection/spec.md`（line 11, 14）
+- **Description**: 正式 spec（`openspec/specs/PPP-004-reply-selection/spec.md`）の Requirement「投稿の内容別グループ化」および Scenario「同じ内容を複数 SNS に投稿」は対象 SNS を `（X、Mastodon、Bluesky）` と記載している。本 delta はこれを `（Mastodon、Bluesky、Threads）` に変更しており、Threads 追加だけでなく **X の削除** も同時に行っている。実装（`frontend/src/lib/MainContent.ts`）の `SettingType` は `mastodon | bluesky | threads` のみで X は存在しないため、X 削除は実態に合わせた正しい修正だが、proposal.md の What Changes には「対象 SNS に Threads を加える」とのみ記載され、X 削除の事実・理由が明示されていない。
+- **Suggestion**: proposal.md の What Changes に「正式 spec に残存していた `X` は現行実装に存在しないため、グループ化対象から削除する」旨を 1 行追記する。仕様の正確性向上が目的で、実装ブロッカーではない。
+
+### Issue 2: spec ディレクトリ名が課題キーを含む（既存慣習に依存）
+- **Severity**: Minor
+- **Location**: `specs/PPP-004-reply-selection/spec.md`
+- **Description**: `openspec/project.md` の命名規則では Spec ディレクトリ名は「課題キーを含めず機能を表す kebab-case」とされている。本 delta の `PPP-004-reply-selection` は課題キーを含む。ただし正式 spec 側（`openspec/specs/PPP-004-reply-selection/`）が既に課題キー付きで存在しており、それと一致させないと別 spec 扱いになるため、delta 側でこの名前を踏襲するのは正しい。本 proposal 固有の不備ではなく、既存 spec 命名の慣習に起因する観察事項。
+- **Suggestion**: 本 proposal では対応不要。将来 PPP-004 spec をリネームする場合は別途検討。
+
+## Checklist
+
+### A. フォーマット検証
+- [x] Requirement に SHALL/MUST が含まれている
+- [x] 各 Requirement に Scenario がある
+- [x] MODIFIED 要件に元の内容が完全に記載（threads-posting テキスト投稿要件、PPP-004 グループ化要件とも要件名が正式版と完全一致。SHALL NOT 制約の解除箇所のみ差分）
+- [x] proposal.md に Why/What Changes/Impact がある
+- [x] openspec validate --strict がパス
+
+### B0. Plan ↔ Proposal/Spec 整合性（plan.md がある場合）
+- [N/A] plan.md は存在しない（references/plan-*.md なし）ためスキップ
+
+### B. 内容面レビュー
+- [x] 要件間に矛盾がない
+- [x] 曖昧な表現がない（「適切に」「必要に応じて」等なし。取得件数も「25 件目安」と具体化）
+- [x] シナリオがテスト可能（接続済み/未接続、取得失敗、画像付き、未選択、失敗通知の各条件が具体的）
+- [x] エッジケース・エラーケースが網羅されている（取得失敗が他 SNS を妨げない / リプライ未選択 / 権限不足での失敗通知）
+- [x] 影響範囲が妥当（threads_posts.js 新規・threads_post.js / MainContent.ts / MainContent.svelte 変更。すべて実在を確認）
+- [x] ビジネスロジックが整合（reply_to_id は API の id を使用、permalink ショートコード非導出。createContainer が任意キーを body 展開するため実装容易）
+- [x] プロジェクトドキュメントと整合（命名規則は Issue 2 の観察あり。それ以外は整合）
+- [x] Spec ↔ Proposal 整合: proposal の意図が spec で網羅されている（自投稿取得 ADDED / リプライ投稿 ADDED / テキスト投稿 MODIFIED で SHALL NOT 解除）
+- [x] Spec ↔ Proposal 整合: 暗黙の前提が spec で明文化されている（permalink から ID 導出禁止を SHALL NOT として明記）
+- [x] Spec ↔ Proposal 整合: 処理経路が完結している（自投稿取得→候補表示→選択→reply_to_id 付与→公開まで Scenario で連続）
+
+### C. ドメイン境界変更の影響分析
+- [x] API フィールド追加の影響を確認（threads_post.js に `reply_to_id` 任意追加。未指定時は従来フロー不変、tasks 2.3 で担保。Post 型に `id?` オプショナル追加で既存 Mastodon/Bluesky は影響なし）
+- [x] DB 列値追加の影響を確認（該当なし）
+- [x] 定数追加の影響を確認（該当なし）
+- [x] テーブルへの新規レコードの影響を確認（該当なし）
+
+### D. タスク計画レビュー
+- [x] 各 Requirement に対応するタスクがある（自投稿取得→1.x/3.2-3.3、リプライ投稿→2.x/3.4-3.6/4.1、グループ化→4.3）
+- [x] 各 Scenario を検証するタスクがある（6.2〜6.8 で候補表示・グループ化・テキスト/画像リプライ・未選択・未接続・他 SNS 回帰を網羅）
+- [x] タスクに対象ファイルが明記されている（threads_posts.js / threads_post.js / MainContent.ts / MainContent.svelte / ThreadsConnection.svelte）
+- [x] タスクの順序が依存関係を考慮している（バックエンド→フロント→スコープ検証→動作検証）
+- [x] 検証/テストタスクが含まれている（5. スコープ検証、6. 動作検証）
+
+## Conclusion
+
+この proposal は OpenSpec の品質基準を満たしており、実装に進めることを推奨します。指摘は Minor 2 件のみで、いずれも実装ブロッカーではありません。Issue 1（proposal への X 削除の明記）は仕様の正確性向上のため対応を推奨します。

--- a/openspec/changes/PPP-012-add-threads-reply/specs/PPP-004-reply-selection/spec.md
+++ b/openspec/changes/PPP-012-add-threads-reply/specs/PPP-004-reply-selection/spec.md
@@ -1,0 +1,22 @@
+# PPP-004-reply-selection Specification
+
+## Overview
+
+リプライ元選択のグループ化対象 SNS に Threads を追加する。グループ化ロジック自体（テキスト正規化・タイムスタンプ表示）は変更しない。
+
+## MODIFIED Requirements
+
+### Requirement: 投稿の内容別グループ化
+
+システムは、リプライ元選択ドロップダウンで表示する投稿を、同一内容のものをグループ化して表示しなければならない (SHALL group posts with identical content)。グループ化の対象は現在対応しているすべての投稿先 SNS（Mastodon、Bluesky、Threads）とする。
+
+#### Scenario: 同じ内容を複数 SNS に投稿
+
+- **WHEN** 同じテキスト内容が複数の SNS（Mastodon、Bluesky、Threads）に投稿されている
+- **THEN** それらの投稿は1つのグループとして表示される
+- **AND** グループ内の各 SNS の投稿情報が保持される
+
+#### Scenario: 異なる内容は別グループになる
+
+- **WHEN** 異なるテキスト内容の投稿がある
+- **THEN** それらは別々のグループとして表示される

--- a/openspec/changes/PPP-012-add-threads-reply/specs/threads-posting/spec.md
+++ b/openspec/changes/PPP-012-add-threads-reply/specs/threads-posting/spec.md
@@ -1,0 +1,88 @@
+# Threads Posting Specification
+
+## Overview
+
+Threads のリプライ対応。本デルタは、テキスト投稿要件から「リプライ先を送信してはならない (SHALL NOT)」制約を解除（MODIFIED）し、自投稿取得とリプライ投稿の要件を新規追加（ADDED）する。
+
+## MODIFIED Requirements
+
+### Requirement: Threads へのテキスト投稿（Post text to Threads）
+
+システムは、Threads が投稿対象に選択されているとき、入力テキストをバックエンド経由で Threads へ投稿しなければならない (SHALL)。バックエンドは、メディアコンテナ作成（`media_type=TEXT`）と公開（`creation_id` 指定）の 2 段階で投稿を行わなければならない (SHALL)。画像を添付して投稿する場合の振る舞いは `### Requirement: Threads への画像投稿` に、リプライ元が選択されている場合の振る舞いは `### Requirement: Threads へのリプライ投稿` に従う。投稿に失敗した場合、システムは失敗を無言で握りつぶしてはならず (SHALL NOT)、エラー一覧に `Threads` を含めてユーザーへ通知しなければならない (SHALL)。
+
+#### Scenario: テキストを Threads に投稿する（Post text successfully）
+
+- **GIVEN** ユーザーが Threads に接続済みで、投稿対象チェックボックスが ON、本文が入力されている
+- **AND** 画像を添付しておらず、リプライ元も選択していない
+- **WHEN** 投稿ボタンを押下する
+- **THEN** バックエンドがコンテナ作成（`media_type=TEXT`）→ 公開の 2 段階で投稿を完了する
+- **AND** Mastodon・Bluesky など他の選択中 SNS への投稿と並行して成功通知が表示される
+
+#### Scenario: 投稿に失敗する（Post fails）
+
+- **GIVEN** ユーザーが Threads を投稿対象に選択している
+- **AND** コンテナ作成または公開のいずれかが失敗する状態である
+- **WHEN** 投稿ボタンを押下する
+- **THEN** エラー一覧に `Threads` が含まれ、ユーザーへ投稿失敗が通知される
+
+## ADDED Requirements
+
+### Requirement: Threads の自投稿取得（Fetch own Threads posts）
+
+システムは、ユーザーがリプライ元選択 UI を展開したとき、Threads に接続済みであれば、バックエンド経由で Threads API（`GET /me/threads`、`fields=id,text,permalink,timestamp`）を呼び出して自投稿一覧を取得し、Mastodon・Bluesky の自投稿と同様にリプライ元候補として表示しなければならない (SHALL)。
+
+取得した各投稿について、システムは Threads API の投稿 `id` を保持しなければならない (SHALL)。permalink の末尾はショートコードであり API の投稿 ID ではないため、permalink から ID を導出してはならない (SHALL NOT)。
+
+Threads の自投稿取得に失敗した場合でも、システムは Mastodon・Bluesky の自投稿候補の表示を妨げてはならない (SHALL NOT)。
+
+#### Scenario: 接続済みで自投稿が候補に表示される（Own posts appear as reply candidates）
+
+- **GIVEN** ユーザーが Threads に接続済みで、Threads に投稿が存在する
+- **WHEN** リプライ元選択 UI を展開する
+- **THEN** Threads の自投稿がリプライ元候補のドロップダウンに表示される
+
+#### Scenario: 未接続時は取得しない（No fetch when not connected）
+
+- **GIVEN** ユーザーが Threads に接続していない
+- **WHEN** リプライ元選択 UI を展開する
+- **THEN** Threads の自投稿取得 API は呼び出されない
+- **AND** Mastodon・Bluesky の自投稿候補は従来通り表示される
+
+#### Scenario: Threads の取得失敗は他 SNS に影響しない（Fetch failure does not block other SNS）
+
+- **GIVEN** ユーザーが Threads に接続済みだが、Threads の自投稿取得が失敗する状態である
+- **WHEN** リプライ元選択 UI を展開する
+- **THEN** Mastodon・Bluesky の自投稿候補は従来通り表示される
+
+### Requirement: Threads へのリプライ投稿（Post reply to Threads）
+
+システムは、リプライ元として Threads の自投稿が選択されているとき、コンテナ作成（`POST /me/threads`）に `reply_to_id`（自投稿取得 API で得た投稿 `id`）を指定して、リプライとして投稿しなければならない (SHALL)。画像付きの場合も同様に、トップレベルのコンテナ（カルーセルの場合は親コンテナ）に `reply_to_id` を付与しなければならない (SHALL)。
+
+リプライ元が選択されていない場合、または選択されたリプライ元グループに Threads の投稿が含まれない場合、システムは `reply_to_id` を付与せず通常投稿として処理しなければならない (SHALL)。
+
+リプライ投稿に失敗した場合、システムはエラー一覧に `Threads` を含めてユーザーへ通知しなければならない (SHALL)。
+
+#### Scenario: 自投稿を選択してリプライする（Reply to own post）
+
+- **GIVEN** ユーザーが Threads に接続済みで、リプライ元として Threads の自投稿を選択し、本文を入力している
+- **WHEN** 投稿ボタンを押下する
+- **THEN** コンテナ作成に `reply_to_id` が付与され、選択した自投稿へのリプライとして公開される
+
+#### Scenario: 画像付きでリプライする（Reply with images）
+
+- **GIVEN** ユーザーがリプライ元として Threads の自投稿を選択し、本文と画像を入力している
+- **WHEN** 投稿ボタンを押下する
+- **THEN** 画像投稿要件に従ったコンテナ（単画像またはカルーセル親）に `reply_to_id` が付与され、リプライとして公開される
+
+#### Scenario: リプライ元未選択時は通常投稿（Normal post without reply selection）
+
+- **GIVEN** ユーザーが Threads を投稿対象に選択し、リプライ元を選択していない
+- **WHEN** 投稿ボタンを押下する
+- **THEN** `reply_to_id` なしの通常投稿として公開される
+
+#### Scenario: リプライ失敗時の通知（Reply failure notification）
+
+- **GIVEN** ユーザーがリプライ元として Threads の自投稿を選択している
+- **AND** リプライ投稿が失敗する状態である（権限不足・元投稿の削除など）
+- **WHEN** 投稿ボタンを押下する
+- **THEN** エラー一覧に `Threads` が含まれ、ユーザーへ投稿失敗が通知される

--- a/openspec/changes/PPP-012-add-threads-reply/tasks.md
+++ b/openspec/changes/PPP-012-add-threads-reply/tasks.md
@@ -1,0 +1,45 @@
+# Implementation Tasks
+
+## 1. バックエンド: 自投稿取得（threads_posts.js）
+
+- [ ] 1.1 `backend/netlify/functions/threads_posts.js` を新規作成する（`mastodon_posts.js` のパターンを踏襲、CORS・OPTIONS プリフライト対応）
+- [ ] 1.2 `POST` body `{ token }` を受け、`GET https://graph.threads.net/v1.0/me/threads?fields=id,text,permalink,timestamp&limit=25&access_token=<token>` を呼ぶ
+- [ ] 1.3 レスポンスを `{ id, text, url, posted_at }[]` 形式（`url` は permalink、`posted_at` は timestamp）で返す
+- [ ] 1.4 失敗時はエラーステータスを返し、`console.error` でログ出力する
+
+## 2. バックエンド: リプライ投稿（threads_post.js）
+
+- [ ] 2.1 body フィールドに `reply_to_id`（任意）を追加で受け取る
+- [ ] 2.2 `reply_to_id` が指定されている場合、トップレベルのコンテナ作成（TEXT / IMAGE / CAROUSEL 親）の API パラメータに `reply_to_id` を付与する（カルーセルの子コンテナには付与しない）
+- [ ] 2.3 `reply_to_id` 未指定時は従来の通常投稿フローを変更しない
+
+## 3. フロントエンド: 投稿処理（MainContent.ts）
+
+- [ ] 3.1 `Post` 型に `id?: string` を追加する（Threads のみ使用。Mastodon・Bluesky は従来通り URL から ID 抽出）
+- [ ] 3.2 `loadMyPostsThreads()` を新規作成する（`POST ${Config.API_ENDPOINT}/threads_posts` に `{ token: postSettings.threads.token_data.access_token }` を送り、`Post[]`（`id` 付き）を返す）
+- [ ] 3.3 `loadMyPosts` の取得対象に Threads を追加する（`Promise.allSettled` の並列取得に加える。Threads の失敗が他 SNS の表示を妨げないこと）
+- [ ] 3.4 `postToSns` の `options.reply_to_ids` に `threads: string` を追加する
+- [ ] 3.5 `postToThreads(text, imageUrls, reply_to_id)` に `reply_to_id` 引数を追加し、リクエスト body に含める（未指定時は送らないか undefined のまま）
+- [ ] 3.6 `postToSns` の `case 'threads'` で `options?.reply_to_ids?.threads` を渡す
+
+## 4. フロントエンド: リプライ元選択（MainContent.svelte）
+
+- [ ] 4.1 投稿時の `reply_to_ids` 構築で `threads: replyToPost?.postOfType['threads']?.id ?? ''` を追加する（`getPostId()` は使わない。design.md D1 参照）
+- [ ] 4.2 Threads 用の手動リプライ ID 入力欄は追加しない（Non-Goal）
+- [ ] 4.3 リプライ元ドロップダウンのグループ表示に Threads が含まれることを確認する（`getTypes()` は `postOfType` のキーを列挙するため変更不要の見込み）
+
+## 5. スコープ検証（design.md D3）
+
+- [ ] 5.1 実機でリプライ投稿を行い、既存スコープ（`threads_basic,threads_content_publish`）で成功するか確認する
+- [ ] 5.2 権限エラーが発生した場合のみ、`ThreadsConnection.svelte` の認可 URL の `scope` に `threads_manage_replies` を追加し、再接続後にリプライ投稿が成功することを確認する
+
+## 6. 動作検証
+
+- [ ] 6.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
+- [ ] 6.2 リプライ元選択 UI を展開し、Threads の自投稿が候補に表示されることを確認する
+- [ ] 6.3 同一内容を Mastodon・Bluesky・Threads に投稿した場合、候補で 1 グループにまとまり `(mastodon, bluesky, threads)` と表示されることを確認する
+- [ ] 6.4 Threads の自投稿を選択してテキストリプライが成功し、Threads 上でリプライとして表示されることを確認する
+- [ ] 6.5 画像付きリプライが成功することを確認する
+- [ ] 6.6 リプライ元未選択時に通常投稿となることを確認する
+- [ ] 6.7 Threads 未接続時に自投稿取得 API が呼ばれず、Mastodon・Bluesky の候補表示が従来通りであることを確認する
+- [ ] 6.8 Mastodon・Bluesky へのリプライ投稿が従来通り動作することを確認する

--- a/openspec/changes/PPP-012-add-threads-reply/tasks.md
+++ b/openspec/changes/PPP-012-add-threads-reply/tasks.md
@@ -2,31 +2,31 @@
 
 ## 1. バックエンド: 自投稿取得（threads_posts.js）
 
-- [ ] 1.1 `backend/netlify/functions/threads_posts.js` を新規作成する（`mastodon_posts.js` のパターンを踏襲、CORS・OPTIONS プリフライト対応）
-- [ ] 1.2 `POST` body `{ token }` を受け、`GET https://graph.threads.net/v1.0/me/threads?fields=id,text,permalink,timestamp&limit=25&access_token=<token>` を呼ぶ
-- [ ] 1.3 レスポンスを `{ id, text, url, posted_at }[]` 形式（`url` は permalink、`posted_at` は timestamp）で返す
-- [ ] 1.4 失敗時はエラーステータスを返し、`console.error` でログ出力する
+- [x] 1.1 `backend/netlify/functions/threads_posts.js` を新規作成する（`mastodon_posts.js` のパターンを踏襲、CORS・OPTIONS プリフライト対応）
+- [x] 1.2 `POST` body `{ token }` を受け、`GET https://graph.threads.net/v1.0/me/threads?fields=id,text,permalink,timestamp&limit=25&access_token=<token>` を呼ぶ
+- [x] 1.3 レスポンスを `{ id, text, url, posted_at }[]` 形式（`url` は permalink、`posted_at` は timestamp）で返す
+- [x] 1.4 失敗時はエラーステータスを返し、`console.error` でログ出力する
 
 ## 2. バックエンド: リプライ投稿（threads_post.js）
 
-- [ ] 2.1 body フィールドに `reply_to_id`（任意）を追加で受け取る
-- [ ] 2.2 `reply_to_id` が指定されている場合、トップレベルのコンテナ作成（TEXT / IMAGE / CAROUSEL 親）の API パラメータに `reply_to_id` を付与する（カルーセルの子コンテナには付与しない）
-- [ ] 2.3 `reply_to_id` 未指定時は従来の通常投稿フローを変更しない
+- [x] 2.1 body フィールドに `reply_to_id`（任意）を追加で受け取る
+- [x] 2.2 `reply_to_id` が指定されている場合、トップレベルのコンテナ作成（TEXT / IMAGE / CAROUSEL 親）の API パラメータに `reply_to_id` を付与する（カルーセルの子コンテナには付与しない）
+- [x] 2.3 `reply_to_id` 未指定時は従来の通常投稿フローを変更しない
 
 ## 3. フロントエンド: 投稿処理（MainContent.ts）
 
-- [ ] 3.1 `Post` 型に `id?: string` を追加する（Threads のみ使用。Mastodon・Bluesky は従来通り URL から ID 抽出）
-- [ ] 3.2 `loadMyPostsThreads()` を新規作成する（`POST ${Config.API_ENDPOINT}/threads_posts` に `{ token: postSettings.threads.token_data.access_token }` を送り、`Post[]`（`id` 付き）を返す）
-- [ ] 3.3 `loadMyPosts` の取得対象に Threads を追加する（`Promise.allSettled` の並列取得に加える。Threads の失敗が他 SNS の表示を妨げないこと）
-- [ ] 3.4 `postToSns` の `options.reply_to_ids` に `threads: string` を追加する
-- [ ] 3.5 `postToThreads(text, imageUrls, reply_to_id)` に `reply_to_id` 引数を追加し、リクエスト body に含める（未指定時は送らないか undefined のまま）
-- [ ] 3.6 `postToSns` の `case 'threads'` で `options?.reply_to_ids?.threads` を渡す
+- [x] 3.1 `Post` 型に `id?: string` を追加する（Threads のみ使用。Mastodon・Bluesky は従来通り URL から ID 抽出）
+- [x] 3.2 `loadMyPostsThreads()` を新規作成する（`POST ${Config.API_ENDPOINT}/threads_posts` に `{ token: postSettings.threads.token_data.access_token }` を送り、`Post[]`（`id` 付き）を返す）
+- [x] 3.3 `loadMyPosts` の取得対象に Threads を追加する（`Promise.allSettled` の並列取得に加える。Threads の失敗が他 SNS の表示を妨げないこと）
+- [x] 3.4 `postToSns` の `options.reply_to_ids` に `threads: string` を追加する
+- [x] 3.5 `postToThreads(text, imageUrls, reply_to_id)` に `reply_to_id` 引数を追加し、リクエスト body に含める（未指定時は送らないか undefined のまま）
+- [x] 3.6 `postToSns` の `case 'threads'` で `options?.reply_to_ids?.threads` を渡す
 
 ## 4. フロントエンド: リプライ元選択（MainContent.svelte）
 
-- [ ] 4.1 投稿時の `reply_to_ids` 構築で `threads: replyToPost?.postOfType['threads']?.id ?? ''` を追加する（`getPostId()` は使わない。design.md D1 参照）
-- [ ] 4.2 Threads 用の手動リプライ ID 入力欄は追加しない（Non-Goal）
-- [ ] 4.3 リプライ元ドロップダウンのグループ表示に Threads が含まれることを確認する（`getTypes()` は `postOfType` のキーを列挙するため変更不要の見込み）
+- [x] 4.1 投稿時の `reply_to_ids` 構築で `threads: replyToPost?.postOfType['threads']?.id ?? ''` を追加する（`getPostId()` は使わない。design.md D1 参照）
+- [x] 4.2 Threads 用の手動リプライ ID 入力欄は追加しない（Non-Goal）
+- [x] 4.3 リプライ元ドロップダウンのグループ表示に Threads が含まれることを確認する（`getTypes()` は `postOfType` のキーを列挙するため変更不要の見込み）
 
 ## 5. スコープ検証（design.md D3）
 
@@ -35,7 +35,7 @@
 
 ## 6. 動作検証
 
-- [ ] 6.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
+- [x] 6.1 `cd frontend && npm run build` が型エラーなく成功することを確認する
 - [ ] 6.2 リプライ元選択 UI を展開し、Threads の自投稿が候補に表示されることを確認する
 - [ ] 6.3 同一内容を Mastodon・Bluesky・Threads に投稿した場合、候補で 1 グループにまとまり `(mastodon, bluesky, threads)` と表示されることを確認する
 - [ ] 6.4 Threads の自投稿を選択してテキストリプライが成功し、Threads 上でリプライとして表示されることを確認する


### PR DESCRIPTION
## Summary
- PPP-012: Threads の自投稿取得とリプライ投稿を実装
- `threads_posts.js` 新規作成（`GET /me/threads` で自投稿を取得し、リプライ元候補に表示）
- `threads_post.js` に `reply_to_id` を追加（テキスト・画像・カルーセルすべて対応、トップレベルコンテナのみ付与）
- リプライ ID は API の投稿 `id` を使用（Threads の permalink 末尾はショートコードのため URL からの抽出は不可）
- Threads の手動リプライ ID 入力欄は非対応（自投稿選択のみ）

## Test plan
- [ ] リプライ元選択 UI に Threads の自投稿が表示される
- [ ] 同一内容の投稿が Mastodon・Bluesky・Threads で 1 グループにまとまる
- [ ] Threads の自投稿を選択してテキストリプライが成功する
- [ ] 画像付きリプライが成功する
- [ ] リプライ元未選択時は通常投稿となる
- [ ] 既存スコープでリプライが失敗する場合は `threads_manage_replies` の追加を検討（design.md D3）
- [ ] Mastodon・Bluesky へのリプライが従来通り動作する

🤖 Generated with [Claude Code](https://claude.ai/code)